### PR TITLE
Revert PyTorch stack to earlier version for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Install PyTorch, TorchVision, and TorchAudio with CUDA 11.8 support
-torch==2.0.0
-torchvision==0.20.1
-torchaudio==2.0.0
+torch==1.13.1
+torchvision==0.14.1
+torchaudio==0.13.1
 
 # Core dependencies
 transformers==4.46.0


### PR DESCRIPTION
 Update PyTorch, TorchVision, and TorchAudio versions:
- Changed `torch` from `2.0.0` to `1.13.1`.
- Changed `torchvision` from `0.20.1` to `0.14.1`.
- Changed `torchaudio` from `2.0.0` to `0.13.1`.

These changes revert the PyTorch stack to an earlier version, which might be necessary for compatibility with certain environments or older codebases that are not yet updated to support PyTorch 2.0.0. This could affect performance and feature availability, as newer versions often include optimizations and new features.