### PR TITLE
Migrate project from JAX to PyTorch framework

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -1,26 +1,22 @@
-import jax
-import jax.numpy as jnp
-from flax import linen as nn
-from flax.training import train_state
-from flax.core import FrozenDict
-from jax.experimental import jax2tf
-from jax.experimental.jax2tf import lower
+import torch
+import torch.nn as nn
+from torch.optim import SGD
 import numpy as np
 from typing import Optional, Callable
 
-def create_optimizer(learning_rate: float):
-    return jax.experimental.optimizers.sgd(learning_rate)
+def create_optimizer(model, learning_rate):
+    return SGD(model.parameters(), lr=learning_rate)
 
 def mean_pooling(hidden_state, attention_mask):
-    input_mask_expanded = attention_mask[:, None].expand(hidden_state.shape).astype(jnp.float32)
-    sum_embeddings = jnp.sum(hidden_state * input_mask_expanded, axis=1)
-    sum_mask = jnp.clip(jnp.sum(input_mask_expanded, axis=1), a_min=1e-9)
+    input_mask_expanded = attention_mask.unsqueeze(1).expand_as(hidden_state).float()
+    sum_embeddings = (hidden_state * input_mask_expanded).sum(dim=1)
+    sum_mask = input_mask_expanded.sum(dim=1).clamp(min=1e-9)
     return sum_embeddings / sum_mask
 
 def triplet_margin_loss(anchor_embeddings, positive_embeddings, negative_embeddings, margin=1.0):
-    return jnp.mean(jnp.maximum(margin + jnp.linalg.norm(anchor_embeddings - positive_embeddings, axis=1) - jnp.linalg.norm(anchor_embeddings - negative_embeddings, axis=1), 0))
+    return (margin + (anchor_embeddings - positive_embeddings).pow(2).sum(dim=1) - (anchor_embeddings - negative_embeddings).pow(2).sum(dim=1)).clamp(min=0).mean()
 
-def compute_loss(params, inputs, model, layer_index=-1):
+def compute_loss(model, inputs, layer_index=-1):
     anchor_input_ids = inputs["anchor_input_ids"]
     anchor_attention_mask = inputs["anchor_attention_mask"]
     positive_input_ids = inputs["positive_input_ids"]
@@ -28,21 +24,21 @@ def compute_loss(params, inputs, model, layer_index=-1):
     negative_input_ids = inputs["negative_input_ids"]
     negative_attention_mask = inputs["negative_attention_mask"]
 
-    anchor_outputs = model.apply({'params': params}, input_ids=anchor_input_ids, attention_mask=anchor_attention_mask)
-    positive_outputs = model.apply({'params': params}, input_ids=positive_input_ids, attention_mask=positive_attention_mask)
-    negative_outputs = model.apply({'params': params}, input_ids=negative_input_ids, attention_mask=negative_attention_mask)
+    anchor_outputs = model(anchor_input_ids, attention_mask=anchor_attention_mask)
+    positive_outputs = model(positive_input_ids, attention_mask=positive_attention_mask)
+    negative_outputs = model(negative_input_ids, attention_mask=negative_attention_mask)
 
-    anchor_hidden_state = anchor_outputs.hidden_states[layer_index]
-    positive_hidden_state = positive_outputs.hidden_states[layer_index]
-    negative_hidden_state = negative_outputs.hidden_states[layer_index]
+    anchor_hidden_state = anchor_outputs.last_hidden_state if layer_index == -1 else anchor_outputs.hidden_states[layer_index]
+    positive_hidden_state = positive_outputs.last_hidden_state if layer_index == -1 else positive_outputs.hidden_states[layer_index]
+    negative_hidden_state = negative_outputs.last_hidden_state if layer_index == -1 else negative_outputs.hidden_states[layer_index]
 
     anchor_embeddings = mean_pooling(anchor_hidden_state, anchor_attention_mask)
     positive_embeddings = mean_pooling(positive_hidden_state, positive_attention_mask)
     negative_embeddings = mean_pooling(negative_hidden_state, negative_attention_mask)
 
-    anchor_embeddings = jax.nn.normalize(anchor_embeddings, axis=1)
-    positive_embeddings = jax.nn.normalize(positive_embeddings, axis=1)
-    negative_embeddings = jax.nn.normalize(negative_embeddings, axis=1)
+    anchor_embeddings = anchor_embeddings / anchor_embeddings.norm(dim=1, keepdim=True)
+    positive_embeddings = positive_embeddings / positive_embeddings.norm(dim=1, keepdim=True)
+    negative_embeddings = negative_embeddings / negative_embeddings.norm(dim=1, keepdim=True)
 
     return triplet_margin_loss(anchor_embeddings, positive_embeddings, negative_embeddings)
 
@@ -56,12 +52,12 @@ def get_item(dataset, idx, num_negatives):
     negative_indices = [i for i in negative_indices if i != anchor_idx]
 
     return {
-        'anchor_input_ids': dataset.samples[anchor_idx],
-        'anchor_attention_mask': np.ones_like(dataset.samples[anchor_idx], dtype=np.long),
-        'positive_input_ids': dataset.samples[positive_idx],
-        'positive_attention_mask': np.ones_like(dataset.samples[positive_idx], dtype=np.long),
-        'negative_input_ids': np.stack([dataset.samples[i] for i in negative_indices]),
-        'negative_attention_mask': np.ones_like(np.stack([dataset.samples[i] for i in negative_indices]), dtype=np.long)
+        'anchor_input_ids': torch.tensor(dataset.samples[anchor_idx]),
+        'anchor_attention_mask': torch.ones_like(torch.tensor(dataset.samples[anchor_idx]), dtype=torch.long),
+        'positive_input_ids': torch.tensor(dataset.samples[positive_idx]),
+        'positive_attention_mask': torch.ones_like(torch.tensor(dataset.samples[positive_idx]), dtype=torch.long),
+        'negative_input_ids': torch.stack([torch.tensor(dataset.samples[i]) for i in negative_indices]),
+        'negative_attention_mask': torch.ones_like(torch.stack([torch.tensor(dataset.samples[i]) for i in negative_indices]), dtype=torch.long)
     }
 
 def get_len(dataset):
@@ -73,23 +69,21 @@ class Dataset:
         self.labels = labels
         self.batch_size = batch_size
 
-def train_step(state, inputs, model, layer_index, optimizer):
-    grads = jax.grad(lambda params: compute_loss(params, inputs, model, layer_index))(state.params)
-    state = state.apply_gradients(grads=grads)
-    return state
+def train_step(model, inputs, optimizer, layer_index):
+    optimizer.zero_grad()
+    loss = compute_loss(model, inputs, layer_index)
+    loss.backward()
+    optimizer.step()
+    return loss.item()
 
 def train(model, dataset, epochs, num_negatives, layer_index, optimizer):
-    state = train_state.TrainState.create(
-        apply_fn=model.apply,
-        params=model.init(jax.random.PRNGKey(0), jnp.ones((1, 1)))['params'],
-        tx=optimizer
-    )
     for epoch in range(epochs):
+        total_loss = 0
         for i in range(get_len(dataset)):
             inputs = get_item(dataset, i, num_negatives)
-            state = train_step(state, inputs, model, layer_index, optimizer)
-        print(f'Epoch {epoch+1}, loss: {compute_loss(state.params, inputs, model, layer_index)}')
-    return state
+            loss = train_step(model, inputs, optimizer, layer_index)
+            total_loss += loss
+        print(f'Epoch {epoch+1}, loss: {total_loss / get_len(dataset)}')
 
 class TripletLossTrainer:
     def __init__(self, 
@@ -100,18 +94,18 @@ class TripletLossTrainer:
         self.model = model
         self.triplet_margin = triplet_margin
         self.layer_index = layer_index
-        self.optimizer = create_optimizer(learning_rate)
+        self.optimizer = create_optimizer(model, learning_rate)
 
     def train(self, dataset, epochs, num_negatives):
-        state = train(self.model, dataset, epochs, num_negatives, self.layer_index, self.optimizer)
-        return state
+        train(self.model, dataset, epochs, num_negatives, self.layer_index, self.optimizer)
 
 if __name__ == "__main__":
     # Initialize dataset
     dataset = Dataset(np.random.rand(100, 10), np.random.randint(0, 2, 100), 32)
 
     # Initialize model and trainer
-    model = nn.Embed(100, 10)
+    model = nn.Embedding(100, 10)
+    model = model.to(torch.float)
     trainer = TripletLossTrainer(model, triplet_margin=1.0, layer_index=-1, learning_rate=1e-4)
 
     # Train model


### PR DESCRIPTION
This pull request migrates the project from JAX to PyTorch. Here are the significant changes made to the code:

The `create_optimizer` function now uses PyTorch's `SGD` optimizer instead of JAX's `sgd` optimizer. The `create_optimizer` function now takes the model as an argument and returns an instance of `SGD` with the model's parameters and the specified learning rate.

The `mean_pooling` function now uses PyTorch's tensor operations instead of JAX's NumPy-like operations. The `mean_pooling` function now uses `unsqueeze` and `expand_as` to expand the attention mask, and `sum` and `clamp` to calculate the sum of embeddings and the sum of the mask.

The `triplet_margin_loss` function now uses PyTorch's tensor operations instead of JAX's NumPy-like operations. The `triplet_margin_loss` function now uses `pow` and `sum` to calculate the squared differences between the anchor and positive embeddings and between the anchor and negative embeddings, and `clamp` and `mean` to calculate the final loss.

The `compute_loss` function now uses PyTorch's model API instead of JAX's `apply` function. The `compute_loss` function now calls the model's `__call__` method to get the outputs, and uses PyTorch's tensor operations to calculate the embeddings and the loss.

The `get_item` function now uses PyTorch's tensor API to create tensors from the dataset's samples and labels.

The `train_step` function now uses PyTorch's autograd API to calculate the gradients and update the model's parameters. The `train_step` function now calls `zero_grad` to reset the gradients, `backward` to calculate the gradients, and `step` to update the parameters.

The `train` function now uses PyTorch's model API and autograd API to train the model. The `train` function now calls `train_step` to train the model for each epoch.

The `TripletLossTrainer` class now uses PyTorch's model API and autograd API to train the model. The `TripletLossTrainer` class now calls `train` to train the model.

Note that this migration requires changes to the model's implementation, as PyTorch's model API is different from JAX's. The model's implementation is not included in this pull request, but it should be updated to use PyTorch's model API.

The dataset's implementation is also not included in this pull request, but it should be updated to work with PyTorch's tensor API.

This migration should improve the project's performance and compatibility with other PyTorch-based projects.