### PR TITLE
Remove explicit CUDA version requirement in PyTorch installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# Install PyTorch, TorchVision, and TorchAudio with CUDA 11.8 support
 torch==2.0.1
 torchvision==0.15.1
 torchaudio==2.0.1


### PR DESCRIPTION
 Removed the comment specifying the installation of PyTorch, TorchVision, and Torchaudio with CUDA 11.8 support. This change implies that the CUDA version requirement is no longer explicitly mentioned in the code, which could affect compatibility considerations for users.