### PR TITLE
 Downgrade PyTorch from 1.13.1 to 1.12.1 for Compatibility and Stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-torch==1.13.1
+torch==1.12.1
 torchvision==0.15.1
 torchaudio==1.13.1
 


### PR DESCRIPTION
Downgrade of PyTorch version from 1.13.1 to 1.12.1.

In this commit, we've downgraded the PyTorch version from 1.13.1 to 1.12.1. This change may be necessary for compatibility or stability reasons, as some dependencies or code may not be compatible with the latest version of PyTorch. The torchvision and torchaudio versions remain the same, as they are not directly affected by this change.