### PR TITLE
Downgrade PyTorch Dependencies for Better Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 plaintext
-torch==1.12.1
-torchvision==0.15.1
-torchaudio==1.13.1
+torch==1.9.0
+torchvision==0.10.0
+torchaudio==0.10.0
 
 # Core dependencies
 transformers==4.47.0


### PR DESCRIPTION
Downgraded key PyTorch dependencies to improve compatibility with a wider range of environments. Specifically, torch is downgraded from 1.12.1 to 1.9.0, torchvision is downgraded from 0.15.1 to 0.10.0, and torchaudio is downgraded from 1.13.1 to 0.10.0. These changes should not affect the functionality of the project but will allow it to work with older versions of PyTorch.