### PR TITLE
Introduce triplet margin toTripletLossTrainer and model persistence

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -130,7 +130,7 @@ class TripletLossTrainer:
             negative_attention_mask
         )
 
-        return triplet_margin_loss(anchor_embeddings, positive_embeddings, negative_embeddings)
+        return triplet_margin_loss(anchor_embeddings, positive_embeddings, negative_embeddings, margin=self.triplet_margin)
 
     def train(self, dataset: Dataset, epochs: int, num_negatives: int) -> None:
         for epoch in range(epochs):
@@ -149,8 +149,18 @@ class TripletLossTrainer:
         self.optimizer.step()
         return loss.item()
 
-if __name__ == "__main__":
+    def save_model(self, path: str) -> None:
+        torch.save(self.model.state_dict(), path)
+
+    def load_model(self, path: str) -> None:
+        self.model.load_state_dict(torch.load(path))
+
+def main():
     dataset = Dataset(np.random.rand(100, 10), np.random.randint(0, 2, 100), 32)
     model = EmbeddingModel(100, 10)
     trainer = TripletLossTrainer(model, triplet_margin=1.0, layer_index=-1, learning_rate=1e-4)
     trainer.train(dataset, epochs=10, num_negatives=5)
+    trainer.save_model("model.pth")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request introduces two significant changes to the existing codebase. The first change involves modifying the `_compute_loss` method in the `TripletLossTrainer` class to pass the `triplet_margin` attribute as an argument to the `triplet_margin_loss` function. This change ensures that the margin value used in the triplet loss calculation is consistent with the value specified during the initialization of the `TripletLossTrainer` instance.

The second change involves adding two new methods, `save_model` and `load_model`, to the `TripletLossTrainer` class. These methods allow for the saving and loading of the trained model's state dictionary to and from a file, respectively. This addition enables the persistence of trained models, facilitating the reuse of pre-trained models and the resumption of training from a previous checkpoint.

In the updated code, the `save_model` method uses PyTorch's `torch.save` function to serialize the model's state dictionary to a file, while the `load_model` method uses PyTorch's `torch.load` function to deserialize the state dictionary from a file and load it into the model. These methods provide a convenient way to manage the lifecycle of trained models, making it easier to integrate the `TripletLossTrainer` class into larger workflows and pipelines.

Additionally, a `main` function has been introduced to demonstrate the usage of the updated `TripletLossTrainer` class. This function creates a sample dataset, initializes a `TripletLossTrainer` instance, trains the model, and saves the trained model to a file named "model.pth".