### PR TITLE
 Update torch version from 1.13.0 to 1.12.1 for compatibility and feature requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.0
+torch==1.12.1
 torchvision==0.13.0
 torchaudio==0.12.0
 


### PR DESCRIPTION
 Updated `torch` version from 1.13.0 to 1.12.1. This change might be due to compatibility issues with other libraries or a specific feature requirement in the 1.12.1 release. It's important to ensure that all other dependencies remain compatible with this new version to avoid any runtime issues.