### PR TITLE
Downgrade torch from 2.0.1 to 1.12.1 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.1
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.12.0
 


### PR DESCRIPTION
Downgrade torch from 2.0.1 to 1.12.1 to address compatibility issues with other dependencies and ensure a stable environment. This change is necessary as some of the dependent libraries may not be fully compatible with the latest version of torch.