### PR TITLE
Refactor EmbeddingModel Class Definition for Simplicity and Predictability

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -4,15 +4,13 @@ from tensorflow.keras.optimizers import SGD
 import numpy as np
 import random
 
-def create_embedding_model(num_embeddings, embedding_dim):
-    class EmbeddingModel(models.Model):
-        def __init__(self):
-            super().__init__()
-            self.embedding = layers.Embedding(num_embeddings, embedding_dim)
+class EmbeddingModel(models.Model):
+    def __init__(self, num_embeddings, embedding_dim):
+        super().__init__()
+        self.embedding = layers.Embedding(num_embeddings, embedding_dim)
 
-        def call(self, input_ids, attention_mask=None):
-            return self.embedding(input_ids)
-    return EmbeddingModel()
+    def call(self, input_ids, attention_mask=None):
+        return self.embedding(input_ids)
 
 def create_triplet_dataset(samples, labels, batch_size, num_negatives):
     class TripletDataset:
@@ -117,7 +115,7 @@ def main():
     num_negatives = 5
     epochs = 10
 
-    model = create_embedding_model(100, 10)
+    model = EmbeddingModel(100, 10)
     dataset = create_triplet_dataset(samples, labels, batch_size, num_negatives)
     trainer = TripletLossTrainer(model, 1.0, 1e-4)
     trainer.train(dataset, epochs, batch_size)


### PR DESCRIPTION
In this updated code, we have refactored the EmbeddingModel class definition. 

The EmbeddingModel class is now defined directly, rather than being created inside a function using a class definition. This change makes the code more straightforward and easier to understand, as the class definition is no longer nested inside a function.

Before this change, the create_embedding_model function would create a new class each time it was called, which could potentially lead to issues if the function was called multiple times. By defining the EmbeddingModel class directly, we avoid this issue and make the code more predictable.

Additionally, we have removed the unnecessary function call when creating an instance of the EmbeddingModel class. Instead of calling `create_embedding_model(100, 10)`, we now call `EmbeddingModel(100, 10)`, which is more intuitive and easier to read.

Overall, this change simplifies the code and makes it easier to understand and maintain.