### PR TITLE
 "Rollback PyTorch version from 1.13.1 to 1.12.1 for stability and compatibility"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.12.1
 torchvision==0.15.1
 torchaudio==0.13.0
 


### PR DESCRIPTION
This pull request is linked to issue #266.
    This pull request updates the PyTorch version from 1.13.1 to 1.12.1. This change is the result of a deliberate decision to roll back to a previous version of PyTorch, which is still compatible with the rest of the dependencies, in order to potentially resolve issues or improve overall stability.

Closes #266