### PR TITLE
Extract Methods from TripletDataset for Improved Modularity and Readability

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -14,6 +14,61 @@ import torchvision
 
 nltk.download('punkt')
 
+def load_dataset(dataset_path):
+    try:
+        return np.load(dataset_path, allow_pickle=True)
+    except FileNotFoundError:
+        print(f"File not found: {dataset_path}")
+        return []
+
+def load_json_file(file_path):
+    try:
+        with open(file_path, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"Failed to load JSON file: {file_path}, error: {str(e)}")
+        return []
+
+def get_subfolder_paths(folder_path):
+    return [os.path.join(folder_path, f) for f in os.listdir(folder_path) if os.path.isdir(os.path.join(folder_path, f))]
+
+def separate_snippets(snippets):
+    return (
+        [item['snippet'] for item in snippets if item.get('is_bug', False) and item.get('snippet')],
+        [item['snippet'] for item in snippets if not item.get('is_bug', False) and item.get('snippet')]
+    )
+
+def create_triplets(problem_statement, positive_snippets, negative_snippets, num_negatives_per_positive):
+    return [{'anchor': problem_statement, 'positive': positive_doc, 'negative': random.choice(negative_snippets)}
+            for positive_doc in positive_snippets
+            for _ in range(min(num_negatives_per_positive, len(negative_snippets)))]
+
+def encode_triplet(triplet, tokenizer, max_length):
+    encoded_triplet = {}
+    for key, text in triplet.items():
+        encoded_text = tokenizer.encode_plus(
+            text=text,
+            max_length=max_length,
+            padding='max_length',
+            truncation=True,
+            return_attention_mask=True,
+            return_tensors='pt'
+        )
+        encoded_triplet[f"{key}_input_ids"] = encoded_text['input_ids'].flatten()
+        encoded_triplet[f"{key}_attention_mask"] = encoded_text['attention_mask'].flatten()
+    return encoded_triplet
+
+def get_item(dataset, instance_id_map, snippet_folder_path, num_negatives_per_positive, index, tokenizer, max_length):
+    folder = os.listdir(snippet_folder_path)[index // num_negatives_per_positive]
+    folder_path = os.path.join(snippet_folder_path, folder)
+    snippet_file = os.path.join(folder_path, 'snippet.json')
+    snippets = load_json_file(snippet_file)
+    bug_snippets, non_bug_snippets = separate_snippets(snippets)
+    problem_statement = instance_id_map.get(folder)
+    triplets = create_triplets(problem_statement, bug_snippets, non_bug_snippets, num_negatives_per_positive)
+    triplet = triplets[index % num_negatives_per_positive]
+    return encode_triplet(triplet, tokenizer, max_length)
+
 class TripletDataset(Dataset):
     def __init__(self, dataset_path, snippet_folder_path):
         self.dataset_path = dataset_path
@@ -24,66 +79,14 @@ class TripletDataset(Dataset):
         self.tokenizer = AutoTokenizer.from_pretrained('bert-base-uncased')
         self.batch_size = 16
 
-    def load_dataset(self):
-        try:
-            return np.load(self.dataset_path, allow_pickle=True)
-        except FileNotFoundError:
-            print(f"File not found: {self.dataset_path}")
-            return []
-
-    def load_json_file(self, file_path):
-        try:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                return json.load(f)
-        except Exception as e:
-            print(f"Failed to load JSON file: {file_path}, error: {str(e)}")
-            return []
-
-    def get_subfolder_paths(self, folder_path):
-        return [os.path.join(folder_path, f) for f in os.listdir(folder_path) if os.path.isdir(os.path.join(folder_path, f))]
-
-    def separate_snippets(self, snippets):
-        return (
-            [item['snippet'] for item in snippets if item.get('is_bug', False) and item.get('snippet')],
-            [item['snippet'] for item in snippets if not item.get('is_bug', False) and item.get('snippet')]
-        )
-
-    def create_triplets(self, problem_statement, positive_snippets, negative_snippets):
-        return [{'anchor': problem_statement, 'positive': positive_doc, 'negative': random.choice(negative_snippets)}
-                for positive_doc in positive_snippets
-                for _ in range(min(self.num_negatives_per_positive, len(negative_snippets)))]
-
-    def encode_triplet(self, triplet):
-        encoded_triplet = {}
-        for key, text in triplet.items():
-            encoded_text = self.tokenizer.encode_plus(
-                text=text,
-                max_length=self.max_length,
-                padding='max_length',
-                truncation=True,
-                return_attention_mask=True,
-                return_tensors='pt'
-            )
-            encoded_triplet[f"{key}_input_ids"] = encoded_text['input_ids'].flatten()
-            encoded_triplet[f"{key}_attention_mask"] = encoded_text['attention_mask'].flatten()
-        return encoded_triplet
-
     def __len__(self):
-        dataset = self.load_dataset()
+        dataset = load_dataset(self.dataset_path)
         return len(dataset) * self.num_negatives_per_positive
 
     def __getitem__(self, index):
-        dataset = self.load_dataset()
+        dataset = load_dataset(self.dataset_path)
         instance_id_map = {item['instance_id']: item['problem_statement'] for item in dataset}
-        folder = os.listdir(self.snippet_folder_path)[index // self.num_negatives_per_positive]
-        folder_path = os.path.join(self.snippet_folder_path, folder)
-        snippet_file = os.path.join(folder_path, 'snippet.json')
-        snippets = self.load_json_file(snippet_file)
-        bug_snippets, non_bug_snippets = self.separate_snippets(snippets)
-        problem_statement = instance_id_map.get(folder)
-        triplets = self.create_triplets(problem_statement, bug_snippets, non_bug_snippets)
-        triplet = triplets[index % self.num_negatives_per_positive]
-        return self.encode_triplet(triplet)
+        return get_item(dataset, instance_id_map, self.snippet_folder_path, self.num_negatives_per_positive, index, self.tokenizer, self.max_length)
 
 
 class TripletModel(LightningModule):


### PR DESCRIPTION
This pull request is linked to issue #300.
    The changes made to the code are primarily aimed at improving modularity and readability. 

The most significant change is the extraction of several methods from the `TripletDataset` class into standalone functions. These functions are now defined at the top level and can be reused elsewhere in the codebase if needed. The methods that were extracted are `load_dataset`, `load_json_file`, `get_subfolder_paths`, `separate_snippets`, `create_triplets`, `encode_triplet`, and `get_item`.

The `get_item` method is now a standalone function that takes in several parameters, including the dataset, instance ID map, snippet folder path, number of negatives per positive, index, tokenizer, and maximum length. This function is responsible for loading the dataset, creating the triplets, and encoding the triplet.

The `TripletDataset` class now only contains the `__len__` and `__getitem__` methods, which are required for a PyTorch dataset class. The `__getitem__` method now simply calls the `get_item` function with the necessary parameters.

Additionally, the `main` function remains the same, but the `TripletModel` class also remains unchanged. The changes made do not affect the functionality of the code, but they do improve the organization and modularity of the code.

The changes also follow the Single Responsibility Principle, which states that a class or function should have only one reason to change. By extracting the methods into standalone functions, each function now has a single responsibility and can be modified independently without affecting the rest of the code.

Overall, the changes made to the code improve its maintainability, readability, and modularity, making it easier to understand and modify in the future.

Closes #300