### PR TITLE
Downgrade PyTorch to 1.13.1 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.13.1
 torchvision==0.15.1
 torchaudio==0.13.0
 


### PR DESCRIPTION
This pull request is linked to issue #316.
    Downgrade PyTorch version from 2.0.0 to 1.13.1 to ensure compatibility and stability with the existing core dependencies and other packages in the project. This change is made to address potential compatibility issues that may arise with the latest PyTorch version, allowing the project to maintain its current functionality and performance.

Closes #316