### PR TITLE
Refactor Dataset and TripletEmbeddingModel for modularity and efficiency

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -4,19 +4,35 @@ import torch.optim as optim
 import torch.utils.data as data
 import numpy as np
 
+def reorder_data(samples):
+    np.random.shuffle(samples)
+    return samples
+
+def construct_triplet_components(idx, samples, labels, batch_size, num_negatives):
+    start_idx = idx * batch_size
+    end_idx = min((idx + 1) * batch_size, len(samples))
+    batch = np.arange(start_idx, end_idx)
+    anchor_idx = batch
+    positive_idx = np.array([np.random.choice(np.where(labels == labels[anchor])[0]) for anchor in anchor_idx])
+    while np.any(positive_idx == anchor_idx):
+        positive_idx = np.array([np.random.choice(np.where(labels == labels[anchor])[0]) for anchor in anchor_idx])
+
+    negative_indices = [np.random.choice(np.where(labels != labels[anchor])[0], num_negatives, replace=False) for anchor in anchor_idx]
+    negative_indices = [np.setdiff1d(negative_idx, [anchor]) for anchor, negative_idx in zip(anchor_idx, negative_indices)]
+    return anchor_idx, positive_idx, negative_indices
+
 class Dataset(data.Dataset):
     def __init__(self, samples, labels, batch_size, num_negatives):
-        self.samples = reorder_data(samples.copy())
+        self.samples = samples
         self.labels = labels
         self.batch_size = batch_size
         self.num_negatives = num_negatives
-        self.epoch = 0
 
     def __len__(self):
         return -(-len(self.samples) // self.batch_size)
 
     def __getitem__(self, idx):
-        anchor_idx, positive_idx, negative_indices = self._construct_triplet_components(idx)
+        anchor_idx, positive_idx, negative_indices = construct_triplet_components(idx, self.samples, self.labels, self.batch_size, self.num_negatives)
         anchor_input_ids = torch.tensor(self.samples[anchor_idx])
         positive_input_ids = torch.tensor(self.samples[positive_idx])
         negative_input_ids = torch.stack([torch.tensor(self.samples[negative_idx]) for negative_idx in negative_indices])
@@ -25,24 +41,6 @@ class Dataset(data.Dataset):
             'positive_input_ids': positive_input_ids,
             'negative_input_ids': negative_input_ids
         }
-
-    def _construct_triplet_components(self, idx):
-        start_idx = idx * self.batch_size
-        end_idx = min((idx + 1) * self.batch_size, len(self.samples))
-        batch = np.arange(start_idx, end_idx)
-        anchor_idx = batch
-        positive_idx = np.array([np.random.choice(np.where(self.labels == self.labels[anchor])[0]) for anchor in anchor_idx])
-        while np.any(positive_idx == anchor_idx):
-            positive_idx = np.array([np.random.choice(np.where(self.labels == self.labels[anchor])[0]) for anchor in anchor_idx])
-
-        negative_indices = [np.random.choice(np.where(self.labels != self.labels[anchor])[0], self.num_negatives, replace=False) for anchor in anchor_idx]
-        negative_indices = [np.setdiff1d(negative_idx, [anchor]) for anchor, negative_idx in zip(anchor_idx, negative_indices)]
-        return anchor_idx, positive_idx, negative_indices
-
-    def __iter__(self):
-        self.epoch += 1
-        self.samples = reorder_data(self.samples.copy())
-        return super().__iter__()
 
 class TripletEmbeddingModel(nn.Module):
     def __init__(self, num_embeddings, embedding_dim):
@@ -55,12 +53,6 @@ class TripletEmbeddingModel(nn.Module):
         x = self.pooling(x.permute(0, 2, 1)).squeeze()
         return x
 
-    def get_triplet_embeddings(self, anchor_input_ids, positive_input_ids, negative_input_ids):
-        anchor_embeddings = self.standardize_vectors(self.forward(anchor_input_ids))
-        positive_embeddings = self.standardize_vectors(self.forward(positive_input_ids))
-        negative_embeddings = self.standardize_vectors(self.forward(negative_input_ids))
-        return anchor_embeddings, positive_embeddings, negative_embeddings
-
     def standardize_vectors(self, embeddings):
         return embeddings / torch.norm(embeddings, dim=1, keepdim=True)
 
@@ -70,31 +62,26 @@ class TripletEmbeddingModel(nn.Module):
                                       torch.sum((anchor_embeddings - negative_embeddings[:, 0, :]) ** 2, dim=1), 
                                       min=0.0))
 
-
-def reorder_data(samples):
-    np.random.shuffle(samples)
-    return samples
-
-
 def train_model(model, dataset, optimizer, margin, epochs):
     for epoch in range(epochs):
         total_loss = 0
+        dataset.samples = reorder_data(dataset.samples.copy())
         for batch in data.DataLoader(dataset, batch_size=1, shuffle=True):
             optimizer.zero_grad()
             anchor_input_ids = batch["anchor_input_ids"].squeeze()
             positive_input_ids = batch["positive_input_ids"].squeeze()
             negative_input_ids = batch["negative_input_ids"].squeeze()
-            anchor_embeddings, positive_embeddings, negative_embeddings = model.get_triplet_embeddings(anchor_input_ids, positive_input_ids, negative_input_ids)
+            anchor_embeddings = model.standardize_vectors(model.forward(anchor_input_ids))
+            positive_embeddings = model.standardize_vectors(model.forward(positive_input_ids))
+            negative_embeddings = model.standardize_vectors(model.forward(negative_input_ids))
             loss = model.evaluate_triplet_loss(anchor_embeddings, positive_embeddings, negative_embeddings, margin)
             loss.backward()
             optimizer.step()
             total_loss += loss.item()
         print(f"Epoch {epoch+1}, Loss: {total_loss / len(dataset)}")
 
-
 def persist_model(model, filename):
     torch.save(model.state_dict(), filename)
-
 
 def main():
     samples = np.random.randint(0, 100, (100, 10))
@@ -110,7 +97,6 @@ def main():
 
     train_model(model, dataset, optimizer, margin, epochs)
     persist_model(model, "model.pth")
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request is linked to issue #366.
    This pull request introduces several changes to the code, primarily aimed at refactoring and improving the overall structure and efficiency. The main changes can be summarized as follows:

The `construct_triplet_components` method has been extracted from the `Dataset` class and is now a standalone function. This change makes the code more modular and easier to test. The `Dataset` class now only focuses on providing the necessary data, while the `construct_triplet_components` function handles the logic of constructing the triplet components.

The `reorder_data` method is now called at the beginning of each epoch in the `train_model` function, rather than in the `__iter__` method of the `Dataset` class. This change ensures that the data is shuffled at the beginning of each epoch, which is a common practice in deep learning.

The `get_triplet_embeddings` method in the `TripletEmbeddingModel` class has been removed, and its functionality has been replaced by direct calls to the `forward` and `standardize_vectors` methods. This change simplifies the code and reduces unnecessary method calls.

The `standardize_vectors` method is now called explicitly in the `train_model` function, rather than relying on the `get_triplet_embeddings` method to do so. This change makes the code more explicit and easier to understand.

The `Dataset` class no longer maintains an internal epoch counter, as this information is not necessary for the dataset itself. The epoch counter is now handled in the `train_model` function, which is responsible for training the model.

Overall, these changes aim to improve the structure and efficiency of the code, making it easier to understand, test, and maintain. They also provide a more explicit and modular approach to constructing the triplet components and training the model.

Closes #366