### PR TITLE
 "Revert torch version from 1.13.1 to 1.12.1 for compatibility and stability"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.12.1
 torchvision==0.13.1
 torchaudio==0.13.1
 


### PR DESCRIPTION
This pull request is linked to issue #372.
     Update `torch` version from 1.13.1 to 1.12.1. This change reverts the PyTorch version to an earlier minor release, which might be necessary for compatibility with specific hardware or software configurations currently in use. This adjustment ensures that the project remains compatible with existing setups and may include necessary bug fixes or performance improvements available in the 1.12.x series.

Closes #372