### PR TITLE
Update TripletLossModel num_embeddings to 101 for Keras Embedding compatibility

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -81,7 +81,7 @@ def main():
     num_negatives = 5
     epochs = 10
 
-    model = TripletLossModel(100, 10)
+    model = TripletLossModel(101, 10)
     dataset = TripletData(samples, labels, batch_size, num_negatives)
     optimizer = tf.keras.optimizers.SGD(learning_rate=1e-4)
     margin = 1.0


### PR DESCRIPTION
This pull request is linked to issue #382.
    The main change in this updated code is the modification of the `TripletLossModel` instance initialization in the `main` function. Specifically, the `num_embeddings` parameter is changed from 100 to 101.

This change is necessary because the `num_embeddings` parameter in the `TripletLossModel` class represents the total number of unique embeddings that the model can learn. In this case, since the samples are generated using `np.random.randint(0, 100, (100, 10))`, the range of possible values is from 0 to 99. However, the `Embedding` layer in Keras requires that the input values are in the range from 0 to `num_embeddings - 1`.

By setting `num_embeddings` to 101, we ensure that the model can learn embeddings for all possible input values, including the maximum value of 99. This change prevents potential out-of-range errors and ensures that the model can learn effectively.

Closes #382