### PR TITLE
Add run_eagerly, loss_fn and training arguments to TripletLossModel

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -55,18 +55,19 @@ class TripletLossModel(tf.keras.Model):
                                          0.0))
 
     def compile(self, optimizer, margin):
-        super(TripletLossModel, self).compile()
+        super(TripletLossModel, self).compile(run_eagerly=True)
         self.optimizer = optimizer
         self.margin = margin
+        self.loss_fn = tf.keras.losses.MeanSquaredError()
 
     def train_step(self, batch):
         with tf.GradientTape() as tape:
             anchor_input_ids = batch["anchor_input_ids"]
             positive_input_ids = batch["positive_input_ids"]
             negative_input_ids = batch["negative_input_ids"]
-            anchor_embeddings = self.standardize_vectors(self(anchor_input_ids))
-            positive_embeddings = self.standardize_vectors(self(positive_input_ids))
-            negative_embeddings = self.standardize_vectors(self(negative_input_ids))
+            anchor_embeddings = self.standardize_vectors(self(anchor_input_ids, training=True))
+            positive_embeddings = self.standardize_vectors(self(positive_input_ids, training=True))
+            negative_embeddings = self.standardize_vectors(self(negative_input_ids, training=True))
             loss = self.triplet_loss(anchor_embeddings, positive_embeddings, negative_embeddings, self.margin)
         gradients = tape.gradient(loss, self.trainable_variables)
         self.optimizer.apply_gradients(zip(gradients, self.trainable_variables))


### PR DESCRIPTION
This pull request is linked to issue #388.
    This pull request introduces a minor but significant change to the existing codebase. The modification is primarily focused on the TripletLossModel class and its compile method.

The primary change is the addition of the run_eagerly=True argument in the compile method of the TripletLossModel class. This argument is used to control whether the model should be run in eager execution mode or not. By setting it to True, the model will be run in eager execution mode, which can be beneficial for debugging purposes.

Additionally, the loss_fn attribute is added to the TripletLossModel class in the compile method. Although it is not used anywhere in the code, it is likely intended to be used in the future to calculate the loss of the model.

Another change is the addition of the training=True argument in the call method when calculating anchor_embeddings, positive_embeddings, and negative_embeddings in the train_step method of the TripletLossModel class. This argument is used to control whether the model should be run in training mode or not. By setting it to True, the model will be run in training mode, which can affect the behavior of certain layers such as dropout and batch normalization.

These changes are minor and do not affect the overall functionality of the code. However, they can potentially improve the performance and debuggability of the model.

It is worth noting that the loss_fn attribute is not used anywhere in the code, and its purpose is unclear. It may be intended to be used in the future to calculate the loss of the model, but for now, it seems unnecessary. 

It is also important to consider the implications of running the model in eager execution mode. While it can be beneficial for debugging purposes, it can also affect the performance of the model. Therefore, it is essential to carefully evaluate the trade-offs before making any changes to the code.

Closes #388