### PR TITLE
 Downgrade torch from 2.1.0 to 2.0.0 to address compatibility issues and ensure stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.1.0
+torch==2.0.0
 torchvision==0.14.0
 torchaudio==0.14.0
 


### PR DESCRIPTION
This pull request is linked to issue #418.
    Downgrade torch from 2.1.0 to 2.0.0, this change is likely to address compatibility issues that have arisen with the latest torch version, and to ensure stability with the existing dependencies in the project.

Closes #418