### PR TITLE
Downgrade PyTorch Libraries to 1.12.0 for Compatibility Assurance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 plaintext
-torch==1.13.0
-torchvision==0.14.0
-torchaudio==0.14.0
+torch==1.12.0
+torchvision==0.13.0
+torchaudio==0.13.0
 
 # Core dependencies
 transformers==4.48.0


### PR DESCRIPTION
This pull request is linked to issue #440.
     Update torch, torchvision, and torchaudio versions to older versions (1.12.0, 0.13.0, and 0.13.0 respectively). This change is significant as it downgrades the core PyTorch libraries, which may affect compatibility with other dependencies and features that rely on newer versions. It's important to ensure that all other dependencies, such as transformers, datasets, accelerate, deepspeed, peft, trl, bitsandbytes, flash-attn, xformers, sentencepiece, tokenizers, tqdm, PyYAML, and safetensors, remain compatible with these older versions of PyTorch.

Closes #440