### PR TITLE
 Update PyTorch from 1.13.0 to 1.12.1 and Check Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.14.0
 


### PR DESCRIPTION
This pull request is linked to issue #452.
     Updated PyTorch version from 1.13.0 to 1.12.1. This change could potentially affect performance and compatibility with other libraries, especially if there were significant updates or bug fixes between these versions. It's important to ensure that all other dependencies continue to work correctly with the new PyTorch version.

Closes #452