### PR TITLE
Updated CustomDataset and DataLoader Initialization for Single Sample Training

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -9,13 +9,12 @@ class CustomDataset(Dataset):
         self.labels = torch.tensor(labels, dtype=torch.long)
         self.batch_size = batch_size
         self.num_negatives = num_negatives
-        self.indices = torch.arange(len(samples))
 
     def __len__(self):
         return (len(self.samples) + self.batch_size - 1) // self.batch_size
 
     def __getitem__(self, idx):
-        indices = torch.randperm(self.indices)
+        indices = torch.randperm(len(self.samples))
         batch = indices[idx * self.batch_size:(idx + 1) * self.batch_size]
 
         anchor_idx = batch
@@ -79,7 +78,7 @@ def main():
 
     model = TripletModel(101, 10, num_negatives)
     dataset = CustomDataset(samples, labels, batch_size, num_negatives)
-    data_loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+    data_loader = DataLoader(dataset, batch_size=1, shuffle=False)
 
     optimizer = optim.SGD(model.parameters(), lr=1e-4)
     for epoch in range(epochs):


### PR DESCRIPTION
This pull request is linked to issue #480.
    The changes made in this updated code are as follows:

In the `CustomDataset` class, the `self.indices` attribute has been removed from the `__init__` method. This attribute was previously used to store the indices of the samples, but it is no longer needed as the `torch.randperm` function is used to shuffle the indices in the `__getitem__` method.

In the `DataLoader` initialization, the `batch_size` has been changed from `batch_size` to `1`. This means that each batch will now contain only one sample, rather than the specified batch size.

The `shuffle` parameter in the `DataLoader` initialization has been changed from `True` to `False`. This means that the data will no longer be shuffled between epochs.

These changes suggest that the model is now being trained with a batch size of 1 and without shuffling the data. This could potentially affect the model's performance and convergence. 

The removal of the `self.indices` attribute from the `CustomDataset` class is a minor change that does not affect the overall functionality of the code. However, the changes to the `DataLoader` initialization could have a significant impact on the model's training process.

It is worth noting that the `batch_size` and `shuffle` parameters are typically set based on the specific requirements of the model and the dataset. In this case, the changes made to these parameters may be intentional and based on a specific use case or requirement. However, without further context, it is difficult to determine the reasoning behind these changes.

In terms of potential issues or concerns, the change to a batch size of 1 could potentially lead to slower training times and reduced model performance. This is because the model will now be processing each sample individually, rather than in batches. Additionally, the lack of shuffling could potentially lead to overfitting, as the model will be seeing the same samples in the same order each epoch.

Closes #480