### PR TITLE
TripletDataset class refactoring to static methods

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -8,6 +8,7 @@ from transformers import AutoModel, AutoTokenizer
 import json
 import numpy as np
 
+# Constants
 INSTANCE_ID_FIELD = 'instance_id'
 MAX_LENGTH = 512
 BATCH_SIZE = 16
@@ -71,7 +72,8 @@ class TripletDataset(Dataset):
             'negative_attention_mask': negative_encoding['attention_mask'].flatten()
         }
 
-    def load_json_file(self, file_path):
+    @staticmethod
+    def load_json_file(file_path):
         try:
             with open(file_path, 'r', encoding='utf-8') as f:
                 return json.load(f)
@@ -79,13 +81,15 @@ class TripletDataset(Dataset):
             print(f"Failed to load JSON file: {file_path}, error: {str(e)}")
             return []
 
-    def separate_snippets(self, snippets):
+    @staticmethod
+    def separate_snippets(snippets):
         return (
             [item['snippet'] for item in snippets if item.get('is_bug', False) and item.get('snippet')],
             [item['snippet'] for item in snippets if not item.get('is_bug', False) and item.get('snippet')]
         )
 
-    def create_triplets(self, problem_statement, positive_snippets, negative_snippets, num_negatives_per_positive):
+    @staticmethod
+    def create_triplets(problem_statement, positive_snippets, negative_snippets, num_negatives_per_positive):
         return [{'anchor': problem_statement, 'positive': positive_doc, 'negative': random.choice(negative_snippets)}
                 for positive_doc in positive_snippets
                 for _ in range(min(num_negatives_per_positive, len(negative_snippets)))]


### PR DESCRIPTION
This pull request is linked to issue #522.
    This pull request addresses the static method declarations in the TripletDataset class. 

The `load_json_file`, `separate_snippets`, and `create_triplets` methods were previously instance methods, but they do not rely on any instance variables or methods of the TripletDataset class. These methods can be safely declared as static methods, which improves the code structure and organization.

Declaring these methods as static methods has several benefits. Firstly, it clarifies the intent of the methods and makes it clear that they do not rely on any instance variables or methods. This makes the code easier to understand and maintain. Secondly, static methods can be called without creating an instance of the class, which can improve performance in certain scenarios.

In terms of changes, the `@staticmethod` decorator has been added to the `load_json_file`, `separate_snippets`, and `create_triplets` methods in the TripletDataset class. This change does not affect the functionality of the code, but it improves the code structure and organization.

Additionally, this change is consistent with the Python coding conventions, which recommend using static methods for methods that do not rely on instance variables or methods.

Overall, this change improves the code quality and maintainability, and it is a step towards making the code more consistent and organized.

Closes #522