### PR TITLE
 Downgrade PyTorch from 2.1.0 to 1.12.1 for Stability and Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.1.0
+torch==1.12.1
 torchvision==0.15.0
 torchaudio==0.14.0
 


### PR DESCRIPTION
This pull request is linked to issue #524.
    Downgrade of PyTorch version from 2.1.0 to 1.12.1. 

This change is significant as it moves the project from the latest version of PyTorch, which is still in its early stages and might be prone to bugs and inconsistencies, to a more stable and widely tested version. PyTorch 1.12.1 is a well-established version with a large user base, which should result in fewer compatibility issues and easier debugging. 

Additionally, this change may also affect the performance and behavior of the project, as different versions of PyTorch can have varying levels of optimization and feature sets. The decision to downgrade to PyTorch 1.12.1 was likely made to prioritize stability and reliability over the potential benefits of using the latest version.

Closes #524