### PR TITLE
"Add on_epoch_end to TripletDataset, Shuffle Dataset after Each Epoch"

### DIFF
--- a/main.py
+++ b/main.py
@@ -100,6 +100,9 @@ class TripletDataset(DatasetBase):
             "attention_mask": self.attention_mask[idx]
         }
 
+    def on_epoch_end(self):
+        self.data = np.random.permutation(self.data)
+
 class BaseModel(nn.Module):
     def __init__(self):
         super(BaseModel, self).__init__()
@@ -146,6 +149,7 @@ class T5Model(BaseModel):
                 optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
+            train_loader.dataset.on_epoch_end()
             print(f"Epoch {epoch+1}, Loss: {loss.item()}")
 
     @classmethod


### PR DESCRIPTION
This pull request is linked to issue #528.
    Changes to the TripletDataset class: 

A new method `on_epoch_end` has been added to the TripletDataset class. This method is used to shuffle the dataset after each epoch when training. This is achieved by using `np.random.permutation` to randomly permute the dataset.

Changes to the T5Model class: 

In the `train` method of the T5Model class, a call to the `on_epoch_end` method of the TripletDataset class has been added at the end of each epoch. This ensures that the dataset is shuffled after each epoch, providing a different set of negative examples for the triplet loss.

Closes #528