### PR TITLE
Fixed T5Model train method to handle datasets without on_epoch_end method.

### DIFF
--- a/main.py
+++ b/main.py
@@ -149,7 +149,8 @@ class T5Model(BaseModel):
                 optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
-            train_loader.dataset.on_epoch_end()
+            if hasattr(train_loader.dataset, 'on_epoch_end'):
+                train_loader.dataset.on_epoch_end()
             print(f"Epoch {epoch+1}, Loss: {loss.item()}")
 
     @classmethod


### PR DESCRIPTION
This pull request is linked to issue #530.
    This pull request addresses a minor issue in the current implementation of the T5Model class. In the previous version of the code, the on_epoch_end method in the TripletDataset class was being called without checking if it existed. This could potentially lead to an AttributeError if the dataset class did not have this method.

To resolve this issue, we added a check in the train method of the T5Model class to verify if the dataset has the on_epoch_end method before calling it. This change ensures that the code is more robust and can handle different types of datasets.

The updated code for the train method is as follows:

@classmethod
def train(cls, model, device, train_loader, num_epochs, use_triplet):
    optimizer = optim.Adam(model.parameters(), lr=0.001)
    for epoch in tqdm(range(num_epochs)):
        for batch in train_loader:
            loss = cls.train_step(model, batch, device, use_triplet)
            optimizer.zero_grad()
            loss.backward()
            optimizer.step()
        if hasattr(train_loader.dataset, 'on_epoch_end'):
            train_loader.dataset.on_epoch_end()
        print(f"Epoch {epoch+1}, Loss: {loss.item()}")

This change will prevent potential errors when working with different dataset classes and make the code more maintainable and efficient.

Closes #530