### PR TITLE
Add GPU Support and Code Improvements for Training

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -58,53 +58,57 @@ class TripletModel(nn.Module):
 
         anchor_embeddings = self.embed(anchor_input_ids)
         positive_embeddings = self.embed(positive_input_ids)
-        negative_embeddings = self.embed(negative_input_ids[:, 0, :])
+        negative_embeddings = self.embed(negative_input_ids.view(-1, input_ids.shape[-1])).view(*negative_input_ids.shape[:-1], -1)
 
         return anchor_embeddings, positive_embeddings, negative_embeddings
 
-def train(model, data_loader, optimizer, epochs):
+def train(model, data_loader, optimizer, epochs, device):
     for epoch in range(epochs):
         running_loss = 0.0
         for i, data in enumerate(data_loader):
+            data = {k: v.to(device) for k, v in data.items()}
             optimizer.zero_grad()
             anchor_embeddings, positive_embeddings, negative_embeddings = model(data)
             if len(positive_embeddings) > 0:
-                loss = model.criterion(anchor_embeddings, positive_embeddings, negative_embeddings)
+                loss = model.criterion(anchor_embeddings, positive_embeddings, negative_embeddings.view(-1, anchor_embeddings.shape[1]))
                 loss.backward()
                 optimizer.step()
                 running_loss += loss.item()
         print(f'Epoch: {epoch+1}, Loss: {running_loss/(i+1):.3f}')
 
-def evaluate(model, data_loader):
+def evaluate(model, data_loader, device):
     model.eval()
     total_loss = 0.0
     with torch.no_grad():
         for i, data in enumerate(data_loader):
+            data = {k: v.to(device) for k, v in data.items()}
             anchor_embeddings, positive_embeddings, negative_embeddings = model(data)
             if len(positive_embeddings) > 0:
-                loss = model.criterion(anchor_embeddings, positive_embeddings, negative_embeddings)
+                loss = model.criterion(anchor_embeddings, positive_embeddings, negative_embeddings.view(-1, anchor_embeddings.shape[1]))
                 total_loss += loss.item()
     print(f'Validation Loss: {total_loss / (i+1):.3f}')
 
-def predict(model, input_ids):
+def predict(model, input_ids, device):
     model.eval()
     with torch.no_grad():
+        input_ids = input_ids.to(device)
         return model.embed(input_ids)
 
 def main():
     torch.manual_seed(42)
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
     samples = torch.randint(0, 100, (100, 10))
     labels = torch.randint(0, 2, (100,))
     batch_size = 32
     num_negatives = 5
     epochs = 10
 
-    model = TripletModel(101, 10, num_negatives)
+    model = TripletModel(101, 10, num_negatives).to(device)
     dataset = TripletDataset(samples, labels, batch_size, num_negatives)
     data_loader = DataLoader(dataset, batch_size=1, shuffle=False)
 
     optimizer = optim.SGD(model.parameters(), lr=1e-4)
-    train(model, data_loader, optimizer, epochs)
+    train(model, data_loader, optimizer, epochs, device)
 
     torch.save(model.state_dict(), 'model.pth')
 


### PR DESCRIPTION
This pull request is linked to issue #536.
    This pull request addresses the addition of support for training on GPU and several improvements to the existing code. The key changes are as follows:

- The `forward` method in the `TripletModel` class now properly handles the negative input IDs. In the previous version, only the first negative input ID was used for each anchor. Now, all negative input IDs are used by reshaping the embeddings to their original shape.

- The `train` and `evaluate` functions now take an additional `device` argument, which specifies the device to use for training and evaluation. This allows the model to be trained on either the CPU or GPU.

- In the `train` and `evaluate` functions, the `data` dictionary is now moved to the specified device before being passed to the model. This ensures that the model's inputs are on the correct device.

- In the `predict` function, the `input_ids` are now moved to the specified device before being passed to the model.

- The `model` is now moved to the specified device in the `main` function before training. This ensures that the model's parameters are on the correct device.

- The `negative_embeddings` are now reshaped to have the same shape as the `anchor_embeddings` when passed to the `criterion` in the `train` and `evaluate` functions. This is necessary because the `TripletMarginLoss` criterion expects the negative embeddings to have the same shape as the anchor embeddings.

These changes allow the model to be trained on a GPU, which can significantly speed up training times for large datasets. Additionally, the changes to the `forward` method ensure that all negative input IDs are used during training, which can improve the model's performance.

Closes #536