### PR TITLE
Downgrade PyTorch version from 2.0.0 to 1.13.1 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.13.1
 torchvision==0.15.2
 torchaudio==0.14.2
 


### PR DESCRIPTION
This pull request is linked to issue #572.
    This update involves a single significant change to the project's dependencies, specifically the version of PyTorch. The version of PyTorch has been downgraded from 2.0.0 to 1.13.1. This change may be necessary for compatibility reasons or to address issues that have arisen with the newer version of PyTorch. The rest of the dependencies remain unchanged, ensuring that the project's functionality and performance are preserved. This targeted update allows the project to maintain its existing features and behavior while adapting to the requirements of the changed dependency.

Closes #572