### PR TITLE
Triplet Model Training Pipeline Improvements for Performance and Stability

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -106,6 +106,9 @@ class TripletDataset:
             'negative': np.array(negative_encodings)
         }
 
+    def on_epoch_end(self):
+        random.shuffle(self.triplets)
+
 def load_json_file(file_path: str) -> List:
     try:
         with open(file_path, 'r', encoding='utf-8') as f:
@@ -178,8 +181,7 @@ def main():
     optimizer = Adam(learning_rate=Config.LEARNING_RATE)
     model_path = 'triplet_model.h5'
     for epoch in range(Config.MAX_EPOCHS):
-        random.shuffle(train_dataset.triplets)
-        train_dataset.triplets = train_dataset.triplets[:len(train_dataset.triplets) // Config.BATCH_SIZE * Config.BATCH_SIZE]
+        train_dataset.on_epoch_end()
         loss = train(model, train_dataset, optimizer)
         print(f'Epoch {epoch+1}, Loss: {loss:.4f}')
         save_model(model, model_path)


### PR DESCRIPTION
This pull request is linked to issue #594.
    This pull request contains changes to the triplet model training pipeline to improve performance and stability. 

The main change is in the `TripletDataset` class, where a new method `on_epoch_end` has been added. This method is called at the end of each epoch to shuffle the training data, which helps to prevent the model from overfitting to a particular ordering of the data. This is a common technique in deep learning to improve model generalization.

In the `main` function, the `train_dataset.on_epoch_end()` method is called at the beginning of each epoch to shuffle the training data before training.

Additionally, the `train_dataset` is no longer truncated to a multiple of the batch size. This was done to ensure that all training data is used, even if the batch size does not divide the total number of samples evenly.

These changes should help to improve the performance and stability of the triplet model, and are expected to have a positive impact on the downstream tasks that rely on this model.

Note that these changes do not affect the model architecture or the loss function, but rather the way the training data is handled and presented to the model.

Closes #594