### PR TITLE
 Update PyTorch and related libraries to older versions: torch 2.0.0 to 1.13.1, torchvision 0.15.2 to 0.14.1, torchaudio 0.14.2 to 0.13.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 plaintext
-torch==2.0.0
-torchvision==0.15.2
-torchaudio==0.14.2
+torch==1.13.1
+torchvision==0.14.1
+torchaudio==0.13.1
 
 # Core dependencies
 transformers==4.48.0


### PR DESCRIPTION
This pull request is linked to issue #604.
     Update PyTorch and related libraries to older versions:
- Downgraded `torch` from version 2.0.0 to 1.13.1.
- Downgraded `torchvision` from version 0.15.2 to 0.14.1.
- Downgraded `torchaudio` from version 0.14.2 to 0.13.1.

This change aligns the project with an older version of the PyTorch ecosystem, potentially to ensure compatibility with existing codebases or specific hardware requirements that might not support the latest versions. It's important to thoroughly test to ensure that this rollback does not introduce regressions or compatibility issues with other dependencies listed.

Closes #604