### PR TITLE
 Downgrade torch version to 1.13.1 for compatibility and stability improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.13.1
 


### PR DESCRIPTION
This pull request is linked to issue #628.
    Downgrade torch version to 1.13.1 for compatibility and stability improvements. This change updates the core dependency of our project, PyTorch, from version 2.0.0 to 1.13.1. The main motivation behind this change is to ensure better compatibility and stability with other dependencies in our project.

Closes #628