### PR TITLE
 Update torch version from 1.14.0 to 1.13.1 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.14.0
+torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.13.1
 


### PR DESCRIPTION
This pull request is linked to issue #648.
     Update `torch` version from 1.14.0 to 1.13.1. This change aligns the project with a slightly older version of PyTorch, which might be necessary for compatibility reasons with other libraries or specific features not available in the newer version. No changes to `torchvision`, `torchaudio`, or any other dependencies indicate that the rest of the stack remains unaffected by this downgrade.

Closes #648