### PR TITLE
 Downgrade PyTorch from 2.0.1 to 1.13.1 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.1
+torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.13.1
 


### PR DESCRIPTION
This pull request is linked to issue #676.
    Downgraded PyTorch version from 2.0.1 to 1.13.1 in order to ensure compatibility with existing dependencies and to prevent potential breaking changes introduced in the latest version. This change aims to maintain stability and avoid unforeseen issues that may arise from using the latest PyTorch version.

Closes #676