### PR TITLE
Downgrade PyTorch to 1.12.1 for dependency compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.1.0
+torch==1.12.1
 torchvision==0.15.0
 torchaudio==0.14.0
 


### PR DESCRIPTION
This pull request is linked to issue #756.
    Downgrade of PyTorch version from 2.1.0 to 1.12.1. This change is intended to address compatibility issues with other dependencies, as the latest version of PyTorch may not be fully supported by all the libraries used in the project. This downgrade ensures that the project remains stable and functional.

Closes #756