### PR TITLE
 Downgrade torch version from 2.0.0 to 1.12.1 for better compatibility with existing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.15.0
 torchaudio==0.14.0
 


### PR DESCRIPTION
This pull request is linked to issue #760.
    Downgrade torch version from 2.0.0 to 1.12.1 for better compatibility with existing dependencies and to avoid potential breaking changes introduced in the latest version. This change ensures that the project remains stable and functional with the current set of dependencies, and allows for more thorough testing before upgrading to the latest torch version.

Closes #760