### PR TITLE
Fix out of bounds error in TripletDataset when batch size does not divide sample count

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -11,7 +11,7 @@ class TripletDataset:
         self.num_negatives = num_negatives
 
     def __getitem__(self, idx):
-        anchor_idx = np.arange(idx * self.batch_size, (idx + 1) * self.batch_size)
+        anchor_idx = np.arange(idx * self.batch_size, min((idx + 1) * self.batch_size, len(self.samples)))
         anchor_labels = self.labels[anchor_idx]
         positive_idx = np.array([np.random.choice(np.where(self.labels == label)[0], size=1)[0] for label in anchor_labels])
         negative_idx = np.array([np.random.choice(np.where(self.labels != label)[0], size=self.num_negatives, replace=False) for label in anchor_labels])
@@ -22,7 +22,7 @@ class TripletDataset:
         }
 
     def __len__(self):
-        return len(self.samples) // self.batch_size
+        return len(self.samples) // self.batch_size + (1 if len(self.samples) % self.batch_size != 0 else 0)
 
 
 class TripletModel(models.Model):


### PR DESCRIPTION
This pull request is linked to issue #762.
    This pull request addresses a critical issue in the `TripletDataset` class where the `anchor_idx` calculation could potentially go out of bounds when the batch size is not a perfect divisor of the number of samples. This issue is now resolved by using the `min` function to ensure that `anchor_idx` does not exceed the length of the samples.

Specifically, the line `anchor_idx = np.arange(idx * self.batch_size, (idx + 1) * self.batch_size)` has been updated to `anchor_idx = np.arange(idx * self.batch_size, min((idx + 1) * self.batch_size, len(self.samples)))`. This change ensures that the `anchor_idx` is always within the valid range of indices for the samples.

Additionally, the `__len__` method of the `TripletDataset` class has been updated to correctly calculate the number of batches when the number of samples is not a perfect multiple of the batch size. The updated line `return len(self.samples) // self.batch_size + (1 if len(self.samples) % self.batch_size != 0 else 0)` takes into account the remaining samples that do not fit into a full batch.

These changes ensure that the `TripletDataset` class can handle cases where the number of samples is not a perfect multiple of the batch size, preventing potential index out of bounds errors and ensuring that all samples are processed correctly.

Closes #762