### PR TITLE
Simplify and Improve Triplet Network Implementation

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -3,127 +3,73 @@ from tensorflow.keras import layers, models
 from tensorflow.keras import backend as K
 import numpy as np
 
-class TripletDataset:
-    def __init__(self, samples, labels, batch_size, num_negatives):
-        self.samples = samples
-        self.labels = labels
-        self.batch_size = batch_size
-        self.num_negatives = num_negatives
+def create_triplet_dataset(samples, labels, batch_size, num_negatives):
+    def dataset():
+        idx = 0
+        while True:
+            anchor_idx = np.arange(idx * batch_size, min((idx + 1) * batch_size, len(samples)))
+            anchor_labels = labels[anchor_idx]
+            positive_idx = np.array([np.random.choice(np.where(labels == label)[0], size=1)[0] for label in anchor_labels])
+            negative_idx = np.array([np.random.choice(np.where(labels != label)[0], size=num_negatives, replace=False) for label in anchor_labels])
+            yield {
+                'anchor_input_ids': samples[anchor_idx],
+                'positive_input_ids': samples[positive_idx],
+                'negative_input_ids': samples[negative_idx]
+            }
+            idx += 1
+            if idx >= len(samples) // batch_size + (1 if len(samples) % batch_size != 0 else 0):
+                idx = 0
+    return dataset
 
-    def __getitem__(self, idx):
-        anchor_idx = np.arange(idx * self.batch_size, min((idx + 1) * self.batch_size, len(self.samples)))
-        anchor_labels = self.labels[anchor_idx]
-        positive_idx = np.array([np.random.choice(np.where(self.labels == label)[0], size=1)[0] for label in anchor_labels])
-        negative_idx = np.array([np.random.choice(np.where(self.labels != label)[0], size=self.num_negatives, replace=False) for label in anchor_labels])
-        return {
-            'anchor_input_ids': self.samples[anchor_idx],
-            'positive_input_ids': self.samples[positive_idx],
-            'negative_input_ids': self.samples[negative_idx]
-        }
+def create_triplet_model(num_embeddings, embedding_dim):
+    inputs = layers.Input(shape=(None,), name='anchor_input_ids')
+    embedding = layers.Embedding(input_dim=num_embeddings, output_dim=embedding_dim)(inputs)
+    pooling = layers.GlobalAveragePooling1D()(embedding)
+    outputs = layers.Lambda(lambda x: x / tf.norm(x, axis=-1, keepdims=True))(pooling)
+    return models.Model(inputs=inputs, outputs=outputs)
 
-    def __len__(self):
-        return len(self.samples) // self.batch_size + (1 if len(self.samples) % self.batch_size != 0 else 0)
-
-
-class TripletModel(models.Model):
-    def __init__(self, num_embeddings, embedding_dim):
-        super(TripletModel, self).__init__()
-        self.embedding = layers.Embedding(input_dim=num_embeddings, output_dim=embedding_dim)
-        self.pooling = layers.GlobalAveragePooling1D()
-
-    def embed(self, input_ids):
-        embeddings = self.embedding(input_ids)
-        embeddings = self.pooling(embeddings)
-        return embeddings / tf.norm(embeddings, axis=-1, keepdims=True)
-
-    def call(self, inputs):
-        anchor_embeddings = self.embed(inputs['anchor_input_ids'])
-        positive_embeddings = self.embed(inputs['positive_input_ids'])
-        negative_embeddings = self.embed(inputs['negative_input_ids'])
-        return anchor_embeddings, positive_embeddings, negative_embeddings
-
-
-class TripletLoss(tf.keras.losses.Loss):
-    def __init__(self, margin=1.0):
-        super(TripletLoss, self).__init__()
-        self.margin = margin
-
-    def call(self, y_true, y_pred):
+def create_triplet_loss(margin):
+    def loss(y_true, y_pred):
         anchor, positive, negative = y_pred
-        return tf.reduce_mean(tf.maximum(tf.norm(anchor - positive, axis=-1) - tf.reduce_min(tf.norm(anchor[:, tf.newaxis] - negative, axis=-1), axis=-1) + self.margin, 0))
+        return tf.reduce_mean(tf.maximum(tf.norm(anchor - positive, axis=-1) - tf.reduce_min(tf.norm(anchor[:, tf.newaxis] - negative, axis=-1), axis=-1) + margin, 0))
+    return loss
 
-
-class TripletTrainer:
-    def __init__(self, model, loss_fn, epochs, lr, dataset):
-        self.model = model
-        self.loss_fn = loss_fn
-        self.epochs = epochs
-        self.lr = lr
-        self.dataset = dataset
-        self.optimizer = tf.keras.optimizers.Adam(learning_rate=self.lr)
-
-    def train_step(self, data):
-        with tf.GradientTape() as tape:
-            anchor_embeddings, positive_embeddings, negative_embeddings = self.model(data)
-            loss = self.loss_fn(None, (anchor_embeddings, positive_embeddings, negative_embeddings))
-        gradients = tape.gradient(loss, self.model.trainable_variables)
-        self.optimizer.apply_gradients(zip(gradients, self.model.trainable_variables))
-        return loss
-
-    def train(self):
-        for epoch in range(self.epochs):
-            total_loss = 0
-            for i, data in enumerate(self.dataset):
-                loss = self.train_step(data)
-                total_loss += loss
-            print(f'Epoch: {epoch+1}, Loss: {total_loss/(i+1):.3f}')
-
-
-class TripletEvaluator:
-    def __init__(self, model, loss_fn, dataset):
-        self.model = model
-        self.loss_fn = loss_fn
-        self.dataset = dataset
-
-    def evaluate_step(self, data):
-        anchor_embeddings, positive_embeddings, negative_embeddings = self.model(data)
-        loss = self.loss_fn(None, (anchor_embeddings, positive_embeddings, negative_embeddings))
-        return loss
-
-    def evaluate(self):
-        total_loss = 0.0
-        for i, data in enumerate(self.dataset):
-            loss = self.evaluate_step(data)
+def train_triplet_model(model, loss_fn, optimizer, dataset, epochs):
+    for epoch in range(epochs):
+        total_loss = 0
+        for i, data in enumerate(dataset()):
+            with tf.GradientTape() as tape:
+                anchor_inputs = data['anchor_input_ids']
+                positive_inputs = data['positive_input_ids']
+                negative_inputs = data['negative_input_ids']
+                anchor_embeddings = model(anchor_inputs)
+                positive_embeddings = model(positive_inputs)
+                negative_embeddings = model(negative_inputs)
+                loss = loss_fn(None, (anchor_embeddings, positive_embeddings, negative_embeddings))
+            gradients = tape.gradient(loss, model.trainable_variables)
+            optimizer.apply_gradients(zip(gradients, model.trainable_variables))
             total_loss += loss
-        print(f'Validation Loss: {total_loss / (i+1):.3f}')
+            if i >= len(dataset.dataset) // dataset.batch_size:
+                break
+        print(f'Epoch: {epoch+1}, Loss: {total_loss/(i+1):.3f}')
 
+def evaluate_triplet_model(model, loss_fn, dataset):
+    total_loss = 0.0
+    for i, data in enumerate(dataset()):
+        anchor_inputs = data['anchor_input_ids']
+        positive_inputs = data['positive_input_ids']
+        negative_inputs = data['negative_input_ids']
+        anchor_embeddings = model(anchor_inputs)
+        positive_embeddings = model(positive_inputs)
+        negative_embeddings = model(negative_inputs)
+        loss = loss_fn(None, (anchor_embeddings, positive_embeddings, negative_embeddings))
+        total_loss += loss
+        if i >= len(dataset.dataset) // dataset.batch_size:
+            break
+    print(f'Validation Loss: {total_loss / (i+1):.3f}')
 
-class TripletPredictor:
-    def __init__(self, model):
-        self.model = model
-
-    def predict(self, input_ids):
-        input_ids = tf.convert_to_tensor(input_ids)
-        return self.model({'anchor_input_ids': input_ids})[0]
-
-
-class TripletModelTrainer:
-    def __init__(self, model, loss_fn, epochs, lr, dataset, validation_dataset):
-        self.model = model
-        self.loss_fn = loss_fn
-        self.epochs = epochs
-        self.lr = lr
-        self.dataset = dataset
-        self.validation_dataset = validation_dataset
-        self.optimizer = tf.keras.optimizers.Adam(learning_rate=self.lr)
-        self.trainer = TripletTrainer(model, loss_fn, epochs, lr, dataset)
-        self.evaluator = TripletEvaluator(model, loss_fn, validation_dataset)
-
-    def train(self):
-        for epoch in range(self.epochs):
-            self.trainer.train()
-            self.evaluator.evaluate()
-
+def predict_triplet_model(model, input_ids):
+    return model(input_ids)
 
 def main():
     np.random.seed(42)
@@ -138,16 +84,17 @@ def main():
     margin = 1.0
     lr = 1e-4
 
-    dataset = TripletDataset(samples, labels, batch_size, num_negatives)
-    validation_dataset = TripletDataset(samples, labels, batch_size, num_negatives)
-    model = TripletModel(num_embeddings, embedding_dim)
-    loss_fn = TripletLoss(margin)
-    trainer = TripletModelTrainer(model, loss_fn, epochs, lr, dataset, validation_dataset)
-    trainer.train()
-
-    predictor = TripletPredictor(model)
+    dataset = tf.data.Dataset.from_generator(create_triplet_dataset(samples, labels, batch_size, num_negatives), output_types={'anchor_input_ids': tf.int32, 'positive_input_ids': tf.int32, 'negative_input_ids': tf.int32})
+    dataset = dataset.batch(batch_size)
+    validation_dataset = tf.data.Dataset.from_generator(create_triplet_dataset(samples, labels, batch_size, num_negatives), output_types={'anchor_input_ids': tf.int32, 'positive_input_ids': tf.int32, 'negative_input_ids': tf.int32})
+    validation_dataset = validation_dataset.batch(batch_size)
+    model = create_triplet_model(num_embeddings, embedding_dim)
+    loss_fn = create_triplet_loss(margin)
+    optimizer = tf.keras.optimizers.Adam(learning_rate=lr)
+    train_triplet_model(model, loss_fn, optimizer, dataset, epochs)
+    evaluate_triplet_model(model, loss_fn, validation_dataset)
     input_ids = tf.convert_to_tensor([1, 2, 3, 4, 5])
-    output = predictor.predict(input_ids)
+    output = predict_triplet_model(model, input_ids)
     print(output)
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request is linked to issue #776.
    This pull request introduces significant changes to the existing codebase, primarily focusing on simplifying and improving the implementation of the triplet network. The main changes are as follows:

The dataset generation has been refactored from a class-based implementation to a function-based implementation using the `tf.data.Dataset.from_generator` API. This change allows for more efficient and flexible data generation, particularly when dealing with large datasets. The `create_triplet_dataset` function now takes in the necessary parameters and returns a generator that yields batches of data.

The triplet model has been simplified by removing the redundant `TripletModel` class and instead using the `models.Model` API to define the model architecture. The `create_triplet_model` function now defines the model architecture using the `layers.Input`, `layers.Embedding`, and `layers.GlobalAveragePooling1D` layers. The model outputs are normalized using a `layers.Lambda` layer.

The triplet loss function has been refactored to a simple function-based implementation. The `create_triplet_loss` function now takes in the margin value and returns a loss function that computes the triplet loss.

The training and evaluation logic has been simplified by removing the redundant `TripletTrainer` and `TripletEvaluator` classes. Instead, the `train_triplet_model` and `evaluate_triplet_model` functions now handle the training and evaluation logic, respectively. These functions take in the necessary parameters, including the model, loss function, optimizer, and dataset.

The prediction logic has been simplified by removing the redundant `TripletPredictor` class. Instead, the `predict_triplet_model` function now handles the prediction logic, taking in the model and input IDs.

In the `main` function, the dataset generation, model creation, and training/evaluation logic have been updated to use the new functions. The `tf.data.Dataset.from_generator` API is used to create the training and validation datasets, and the `train_triplet_model` and `evaluate_triplet_model` functions are used to train and evaluate the model, respectively.

These changes aim to simplify the codebase, improve efficiency, and make it easier to maintain and extend the triplet network implementation.

Closes #776