### PR TITLE
 Update torch version from 2.0.0 to 1.13.0 for compatibility with older libraries and hardware requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.13.0
 torchvision==0.15.1
 torchaudio==0.14.1
 


### PR DESCRIPTION
This pull request is linked to issue #796.
     Update `torch` version from 2.0.0 to 1.13.0, which is a significant downgrade. This change may be necessary for compatibility with older libraries or specific hardware requirements that are not supported in the newer version. No changes were made to other PyTorch-related packages (`torchvision` and `torchaudio`), indicating that the downgrade is not expected to affect these components. The rest of the dependencies remain unchanged, suggesting that the project should maintain its current functionality and performance characteristics with this updated version of `torch`.

Closes #796