### PR TITLE
Update PyTorch from 1.13.1 to 1.12.1 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.12.1
 torchvision==0.15.2
 torchaudio==0.14.1
 


### PR DESCRIPTION
This pull request is linked to issue #842.
     Updated PyTorch version from 1.13.1 to 1.12.1. This change may affect performance and compatibility with other libraries. Please ensure all functionalities are tested accordingly.

Closes #842