### PR TITLE
Triplet Model Performance and Accuracy Improvements

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -122,7 +122,7 @@ class TripletDataset:
             anchors = np.stack([item['anchor'] for item in batch])
             positives = np.stack([item['positive'] for item in batch])
             negatives = np.stack([item['negative'] for item in batch])
-            yield anchors, positives, negatives
+            yield jnp.array(anchors), jnp.array(positives), jnp.array(negatives)
 
 def load_json_file(file_path):
     try:
@@ -201,7 +201,7 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained('distilbert-base-uncased')
     train_dataset, test_dataset = load_data(dataset_path, snippet_folder_path, tokenizer)
     model = TripletModel(jax.random.PRNGKey(0), tokenizer)
-    model.init(jax.random.PRNGKey(0), (-1, 768))
+    model.init(jax.random.PRNGKey(0), (-1, Config.MAX_LENGTH))
     model_path = 'triplet_model.npy'
     history = {'loss': [], 'val_loss': []}
     for epoch in range(Config.MAX_EPOCHS):


### PR DESCRIPTION
This pull request is linked to issue #864.
    This pull request includes a few key changes to the existing codebase, aimed at improving the overall performance and accuracy of the triplet model.

Firstly, we've made a significant change in the `TripletDataset` class. Specifically, in the `batch` method, we've modified the way we yield the batches. Instead of returning a tuple of numpy arrays, we now return a tuple of JAX arrays. This change is necessary because our model is built using JAX, and we want to ensure that all computations are performed in the JAX ecosystem. By returning JAX arrays, we can avoid unnecessary conversions between numpy and JAX.

Secondly, we've made a change in the `main` function. When initializing the model, we've changed the input shape from `(-1, 768)` to `(-1, Config.MAX_LENGTH)`. This change is necessary because the `encode` method of the model returns a JAX array with shape `(batch_size, max_length)`, where `max_length` is the maximum length of the input sequence. By setting the input shape to `(-1, Config.MAX_LENGTH)`, we ensure that the model is initialized with the correct input shape.

These changes should improve the overall performance and accuracy of the triplet model. By using JAX arrays throughout the computation graph, we can take advantage of JAX's just-in-time compilation and automatic differentiation capabilities. Additionally, by setting the correct input shape, we can ensure that the model is initialized correctly and produces accurate results.

Closes #864