### PR TITLE
 "Revert PyTorch to 1.12.1 for stability, maintain other deps unchanged"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.15.2
 torchaudio==0.14.1
 


### PR DESCRIPTION
This pull request is linked to issue #866.
    This update modifies the version of the PyTorch library, reverting from version 2.0.0 to version 1.12.1, while keeping all other dependencies unchanged. This change is likely due to compatibility issues or instability with the latest PyTorch version, and aims to provide a more stable environment for the project. The torchvision and torchaudio versions remain the same, as they are not directly impacted by the change in PyTorch version.

Closes #866