### PR TITLE
 Update `torch` version from 2.0.0 to 1.12.1 for compatibility or feature requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.15.2
 torchaudio==0.14.1
 


### PR DESCRIPTION
This pull request is linked to issue #878.
     Update `torch` version from 2.0.0 to 1.12.1. This change is significant as it moves the codebase to an earlier version of PyTorch. This might be due to compatibility issues with other dependencies or specific features required from the 1.x series.

Closes #878