### PR TITLE
Downgrade PyTorch to 1.12.1 for stability and compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.15.2
 torchaudio==0.14.1
 


### PR DESCRIPTION
This pull request is linked to issue #904.
    Downgraded torch version from 2.0.0 to 1.12.1 to utilize a more stable and widely-compatible version of the library, potentially addressing compatibility issues with other dependencies. This change may also impact performance, as the newer version of PyTorch introduced significant updates and optimizations. The rest of the dependencies remain unchanged, suggesting that the project's core functionality and requirements have not been altered.

Closes #904