### PR TITLE
Refactor Triplet Model Code for Improved Readability

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -5,47 +5,51 @@ from torch.utils.data import Dataset, DataLoader
 import numpy as np
 
 def create_triplet_dataset(samples, labels, batch_size, num_negatives):
-    def __len__():
+    def calculate_length():
         return -(-len(samples) // batch_size)
 
-    def __getitem__(idx):
-        anchor_idx = np.arange(idx * batch_size, min((idx + 1) * batch_size, len(samples)))
+    def retrieve_item(idx):
+        start_idx = idx * batch_size
+        end_idx = min((idx + 1) * batch_size, len(samples))
+        anchor_idx = np.arange(start_idx, end_idx)
         anchor_labels = labels[anchor_idx]
+        
         positive_idx = np.array([np.random.choice(np.where(labels == label)[0], size=1)[0] for label in anchor_labels])
         negative_idx = np.array([np.random.choice(np.where(labels != label)[0], size=num_negatives, replace=False) for label in anchor_labels])
+        
         return {
             'anchor_input_ids': torch.tensor(samples[anchor_idx], dtype=torch.long),
             'positive_input_ids': torch.tensor(samples[positive_idx], dtype=torch.long),
             'negative_input_ids': torch.tensor(samples[negative_idx], dtype=torch.long)
         }
 
-    def get_samples():
+    def fetch_samples():
         return samples
 
-    def get_labels():
+    def fetch_labels():
         return labels
 
-    def get_batch_size():
+    def fetch_batch_size():
         return batch_size
 
-    def get_num_negatives():
+    def fetch_num_negatives():
         return num_negatives
 
-    def get_info():
-        print("Dataset info:")
-        print(f"  Samples: {samples.shape}")
-        print(f"  Labels: {labels.shape}")
-        print(f"  Batch size: {batch_size}")
-        print(f"  Number of negatives: {num_negatives}")
+    def print_dataset_info():
+        print("Dataset Information:")
+        print(f"  Number of Samples: {samples.shape}")
+        print(f"  Number of Labels: {labels.shape}")
+        print(f"  Batch Size: {batch_size}")
+        print(f"  Number of Negatives: {num_negatives}")
 
     return type('TripletDataset', (), {
-        '__len__': __len__,
-        '__getitem__': __getitem__,
-        'get_samples': get_samples,
-        'get_labels': get_labels,
-        'get_batch_size': get_batch_size,
-        'get_num_negatives': get_num_negatives,
-        'get_info': get_info
+        '__len__': calculate_length,
+        '__getitem__': retrieve_item,
+        'fetch_samples': fetch_samples,
+        'fetch_labels': fetch_labels,
+        'fetch_batch_size': fetch_batch_size,
+        'fetch_num_negatives': fetch_num_negatives,
+        'print_dataset_info': print_dataset_info
     })
 
 def create_triplet_network(num_embeddings, embedding_dim):
@@ -55,20 +59,20 @@ def create_triplet_network(num_embeddings, embedding_dim):
         nn.Lambda(lambda x: x / torch.norm(x, dim=-1, keepdim=True))
     )
 
-    def forward(inputs):
+    def forward_pass(inputs):
         return model(inputs)
 
-    def get_embedding_dim():
+    def fetch_embedding_dim():
         return model[1].out_features
 
-    def get_model_summary():
-        print("Model summary:")
+    def print_model_summary():
+        print("Model Architecture:")
         print(model)
 
     return type('TripletNetwork', (), {
-        'forward': forward,
-        'get_embedding_dim': get_embedding_dim,
-        'get_model_summary': get_model_summary
+        'forward_pass': forward_pass,
+        'fetch_embedding_dim': fetch_embedding_dim,
+        'print_model_summary': print_model_summary
     })
 
 def create_triplet_model(num_embeddings, embedding_dim, margin, learning_rate, device):
@@ -76,70 +80,78 @@ def create_triplet_model(num_embeddings, embedding_dim, margin, learning_rate, d
     loss_fn = nn.MarginRankingLoss(margin=margin, reduction='mean')
     optimizer = optim.Adam(model.parameters(), lr=learning_rate)
 
-    def train(dataloader, epochs):
+    def train_model(dataloader, epochs):
         for epoch in range(epochs):
             total_loss = 0.0
             for i, data in enumerate(dataloader):
                 anchor_inputs = data['anchor_input_ids'].to(device)
                 positive_inputs = data['positive_input_ids'].to(device)
                 negative_inputs = data['negative_input_ids'].to(device)
-                anchor_embeddings = model.forward(anchor_inputs)
-                positive_embeddings = model.forward(positive_inputs)
-                negative_embeddings = model.forward(negative_inputs)
+                
+                anchor_embeddings = model.forward_pass(anchor_inputs)
+                positive_embeddings = model.forward_pass(positive_inputs)
+                negative_embeddings = model.forward_pass(negative_inputs)
+                
                 anchor_positive_distance = torch.norm(anchor_embeddings - positive_embeddings, dim=-1)
                 anchor_negative_distance = torch.norm(anchor_embeddings[:, None] - negative_embeddings, dim=-1)
+                
                 min_anchor_negative_distance = torch.min(anchor_negative_distance, dim=-1)[0]
                 loss = loss_fn(min_anchor_negative_distance, anchor_positive_distance, torch.ones_like(min_anchor_negative_distance))
+                
                 optimizer.zero_grad()
                 loss.backward()
                 optimizer.step()
                 total_loss += loss.item()
             print(f'Epoch: {epoch+1}, Loss: {total_loss/(i+1):.3f}')
 
-    def evaluate(dataloader):
+    def evaluate_model(dataloader):
         total_loss = 0.0
         with torch.no_grad():
             for i, data in enumerate(dataloader):
                 anchor_inputs = data['anchor_input_ids'].to(device)
                 positive_inputs = data['positive_input_ids'].to(device)
                 negative_inputs = data['negative_input_ids'].to(device)
-                anchor_embeddings = model.forward(anchor_inputs)
-                positive_embeddings = model.forward(positive_inputs)
-                negative_embeddings = model.forward(negative_inputs)
+                
+                anchor_embeddings = model.forward_pass(anchor_inputs)
+                positive_embeddings = model.forward_pass(positive_inputs)
+                negative_embeddings = model.forward_pass(negative_inputs)
+                
                 anchor_positive_distance = torch.norm(anchor_embeddings - positive_embeddings, dim=-1)
                 anchor_negative_distance = torch.norm(anchor_embeddings[:, None] - negative_embeddings, dim=-1)
+                
                 min_anchor_negative_distance = torch.min(anchor_negative_distance, dim=-1)[0]
                 loss = loss_fn(min_anchor_negative_distance, anchor_positive_distance, torch.ones_like(min_anchor_negative_distance))
+                
                 total_loss += loss.item()
         print(f'Validation Loss: {total_loss / (i+1):.3f}')
 
-    def predict(input_ids):
+    def make_prediction(input_ids):
         with torch.no_grad():
-            return model.forward(input_ids.to(device))
+            return model.forward_pass(input_ids.to(device))
 
-    def get_device():
+    def fetch_device():
         return device
 
-    def get_model():
+    def fetch_model():
         return model
 
-    def get_optimizer():
+    def fetch_optimizer():
         return optimizer
 
-    def get_model_info():
-        print("Model info:")
+    def print_model_info():
+        print("Model Information:")
         print(f"  Device: {device}")
         print(f"  Model: {model}")
         print(f"  Optimizer: {optimizer}")
 
     return type('TripletModel', (), {
-        'train': train,
-        'evaluate': evaluate,
-        'predict': predict,
-        'get_device': get_device,
-        'get_model': get_model,
-        'get_optimizer': get_optimizer,
-        'get_model_info': get_model_info
+        'train_model': train_model,
+        'evaluate_model': evaluate_model,
+        'make_prediction': make_prediction,
+        'fetch_device': fetch_device,
+        'fetch_model': fetch_model,
+        'fetch_optimizer': fetch_optimizer,
+        'print_model_info': print_model_info
     })()
 
 def main():
@@ -162,18 +174,17 @@ def main():
     validation_dataloader = DataLoader(validation_dataset, batch_size=batch_size, shuffle=True)
 
     model = create_triplet_model(num_embeddings, embedding_dim, margin, lr, device)()
-    model.train(dataloader, epochs)
-    model.evaluate(validation_dataloader)
+    model.train_model(dataloader, epochs)
+    model.evaluate_model(validation_dataloader)
     input_ids = torch.tensor([1, 2, 3, 4, 5], dtype=torch.long)
-    output = model.predict(input_ids)
+    output = model.make_prediction(input_ids)
     print(output)
 
-    # Example usage of new methods
-    dataset.get_info()
-    model.get_model_info()
-    print(model.get_device())
-    print(model.get_model())
-    print(model.get_optimizer())
+    dataset.print_dataset_info()
+    model.print_model_info()
+    print(model.fetch_device())
+    print(model.fetch_model())
+    print(model.fetch_optimizer())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request is linked to issue #932.
    This pull request introduces a refactored version of the triplet model code. The changes aim to improve code readability, maintainability, and consistency. 

The main changes are in the function and method names. The original code used single words or abbreviations, which made it hard to understand what each function or method does. The refactored code uses more descriptive names that clearly indicate their purpose.

For example, in the `create_triplet_dataset` function, the `__len__` method is renamed to `calculate_length`, `__getitem__` is renamed to `retrieve_item`, and `get_info` is renamed to `print_dataset_info`. Similarly, in the `create_triplet_network` function, the `forward` method is renamed to `forward_pass`, and `get_model_summary` is renamed to `print_model_summary`.

The `create_triplet_model` function also underwent similar changes, with `train` renamed to `train_model`, `evaluate` renamed to `evaluate_model`, and `predict` renamed to `make_prediction`. The `get_model_info` method is renamed to `print_model_info`.

Additionally, the variable names in the `main` function were not changed, but the calls to the model's methods were updated to reflect the new method names.

These changes improve the code's readability and make it easier for new contributors to understand the codebase. The refactored code maintains the same functionality as the original code and does not introduce any new bugs.

The updated code uses more descriptive names for functions and methods, making it easier for developers to understand the purpose of each part of the code. This change is in line with the project's goal of making the code more maintainable and accessible to new contributors.

Closes #932