### PR TITLE
 Revert Torch Version from 2.0.0 to 1.13.1 for Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.13.1
 torchvision==0.15.2
 torchaudio==0.14.1
 


### PR DESCRIPTION
This pull request is linked to issue #966.
    This pull request updates the torch version from 2.0.0 to 1.13.1, reverting to a previous version for compatibility reasons. The change is likely made to address issues related to the latest torch version, possibly due to breaking changes or incompatibilities with other dependencies in the project.

Closes #966