### PR TITLE
Downgrade torch version to 1.13.1 for stability and compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.13.1
 torchvision==0.15.2
 torchaudio==0.14.1
 


### PR DESCRIPTION
This pull request is linked to issue #974.
     Update `torch` version from 2.0.0 to 1.13.1. This change likely reflects a need for stability or compatibility with other components of the system that are not yet ready for the latest version of PyTorch. The downgrade ensures that the project continues to function correctly with the current ecosystem while possibly preparing for future upgrades.

Closes #974