### PR TITLE
Downgrade torch version to 1.12.1 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.15.2
 torchaudio==0.14.1
 


### PR DESCRIPTION
This pull request is linked to issue #980.
    Downgraded torch version from 2.0.0 to 1.12.1 to ensure compatibility with the existing dependencies and resolve potential issues that may arise from the latest version. This change allows the project to maintain stability while still leveraging the benefits of PyTorch.

Closes #980