### PR TITLE
"Fix DataProcessor usage in train_epoch function and Trainer class"

### DIFF
--- a/main.py
+++ b/main.py
@@ -114,7 +114,7 @@ def execute_train_step(state, batch, use_triplet):
 
 def train_epoch(model, state, dataset, use_triplet):
     return jax.jit(lambda state, dataset: jax.lax.fori_loop(
-        0, len(dataset), lambda i, state: execute_train_step(state, next(dataset), use_triplet), state
+        0, len(dataset), lambda i, state: execute_train_step(state, next(iter(dataset)), use_triplet), state
     ))(state, dataset)
 
 class Trainer:
@@ -132,7 +132,7 @@ class Trainer:
         state = create_train_state(rng, model, 0.001)
 
         for epoch in range(self.training_args.num_train_epochs):
-            state = train_epoch(model, state, train_dataset, self.model_args.use_triplet_loss_trainer)
+            state = train_epoch(model, state, iter(train_dataset), self.model_args.use_triplet_loss_trainer)
             print(f"Epoch {epoch+1}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request is linked to issue #1031.
    This pull request makes a key adjustment in the train_epoch function and its usage in the Trainer class. 

In the original code, the DataProcessor instance is passed directly to the train_epoch function. However, DataProcessor is an iterator and its usage should be wrapped with the iter function. 

This change is necessary because the train_epoch function is using jax.lax.fori_loop which does not handle iterators directly. It requires an iterable, which is the result of calling the iter function on the DataProcessor instance.

Additionally, the train_epoch function now uses next(iter(dataset)) instead of next(dataset) to get the next batch from the dataset. This change is necessary because the dataset is an iterator and it needs to be iterated over in each iteration of the fori_loop.

The train function in the Trainer class has also been updated to pass iter(train_dataset) to the train_epoch function, ensuring that the DataProcessor instance is properly iterated over.

Closes #1031