### PR TITLE
Downgrade PyTorch from 1.13.1 to 1.12.1 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.12.1
 torchvision==0.16.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #1051.
    Downgrade of PyTorch version from 1.13.1 to 1.12.1. This change may potentially affect the performance and functionality of certain models, and users should verify that their specific use cases are not impacted by this version change. No other dependencies have been updated or modified.

Closes #1051