### PR TITLE
 Update `torch` version from 2.0.1 to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.1
+torch==2.0.0
 torchvision==0.16.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #1069.
     `torch` version updated from 2.0.1 to 2.0.0. This change indicates a rollback to a previous version of PyTorch, which might be intended to address specific bugs, compatibility issues, or to align with other dependencies that require an earlier version of PyTorch.

Closes #1069