### PR TITLE
Introduce save and load functionality to TripletModel class

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -114,6 +114,11 @@ class TripletModel:
     def predict(self, input_ids):
         return self.network(input_ids)
 
+    def save_model(self, path):
+        self.network.save(path)
+
+    def load_model(self, path):
+        self.network = tf.keras.models.load_model(path)
 
 def main():
     np.random.seed(42)
@@ -136,7 +141,9 @@ def main():
     input_ids = tf.constant([1, 2, 3, 4, 5], dtype=tf.int32)[None, :]
     output = model.predict(input_ids)
     print(output)
-
+    model.save_model("triplet_model.h5")
+    model.load_model("triplet_model.h5")
+    print("Model saved and loaded successfully.")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request is linked to issue #1071.
    This pull request introduces two new methods to the TripletModel class: save_model and load_model. These methods allow users to save and load their trained models using the standard Keras model saving and loading functionality.

The save_model method takes a path as an argument and saves the model to that location using the save method provided by the Keras Model class. This method can be used to save a trained model for later use or to share it with others.

The load_model method also takes a path as an argument and loads a saved model from that location using the load_model function provided by the tf.keras.models module. This method can be used to load a previously trained model and use it for predictions or further training.

In the main function, we demonstrate how to use these new methods by training a model, saving it to a file, loading it back, and printing a message to confirm that the model was saved and loaded successfully.

With these changes, users now have the ability to save and load their models, making it easier to work with and share trained models. 

The changes made to the main function are for demonstration purposes only and are not part of the main functionality of the code.

Closes #1071