### PR TITLE
Modified loss calculation for triplet mode to ensure non-negative result

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def create_train_state(rng, model, learning_rate):
 
 def calculate_loss(params, batch, triplet_mode, model):
     if triplet_mode:
-        return jnp.mean((model.apply({'params': params}, batch["input_ids"]) - batch["positive_labels"])**2 - (model.apply({'params': params}, batch["input_ids"]) - batch["negative_labels"])**2)
+        return jnp.mean(jnp.maximum((model.apply({'params': params}, batch["input_ids"]) - batch["positive_labels"])**2 - (model.apply({'params': params}, batch["input_ids"]) - batch["negative_labels"])**2, 0))
     else:
         return jnp.mean((model.apply({'params': params}, batch["input_ids"]) - batch["labels"])**2)
 


### PR DESCRIPTION
This pull request is linked to issue #1075.
    The main significant changes in this code are in the calculate_loss function where the loss calculation for the triplet mode has been modified to ensure that the result is always non-negative.

Specifically, the line `return jnp.mean((model.apply({'params': params}, batch["input_ids"]) - batch["positive_labels"])**2 - (model.apply({'params': params}, batch["input_ids"]) - batch["negative_labels"])**2)` has been changed to `return jnp.mean(jnp.maximum((model.apply({'params': params}, batch["input_ids"]) - batch["positive_labels"])**2 - (model.apply({'params': params}, batch["input_ids"]) - batch["negative_labels"])**2, 0))`.

This change is necessary because the original calculation could potentially result in a negative value, which is not valid for a loss function. The `jnp.maximum` function ensures that the result is always non-negative by replacing any negative values with 0.

This change is likely intended to improve the stability and convergence of the training process, as negative loss values can cause the model to diverge or converge to a suboptimal solution. By ensuring that the loss is always non-negative, the model is able to learn more effectively and converge to a better solution.

The rest of the code remains unchanged, including the model architecture, dataset loading and processing, and training loop. Therefore, the overall behavior and functionality of the code should remain the same, with the only change being the improved stability and convergence of the training process.

Closes #1075