### PR TITLE
 Update PyTorch version from 1.13.1 to 1.10.2 for older hardware compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.10.2
 torchvision==0.16.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #1081.
     Update the PyTorch version from 1.13.1 to 1.10.2 to maintain compatibility with older hardware and software environments. This change ensures that the project remains accessible to a broader range of users and systems, potentially increasing stability and performance on older infrastructure.

Closes #1081