### PR TITLE
Downgrade PyTorch to 1.12.1 for improved compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.12.1
 torchvision==0.16.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #1117.
    Downgrade torch version from 1.13.1 to 1.12.1 to improve compatibility and resolve potential issues with certain dependencies that may not be fully supported by the latest torch version. This change should not have a significant impact on the overall performance of the project.

Closes #1117