### PR TITLE
Downgrade PyTorch library from 2.0.0 to 1.12.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.16.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #1136.
    The primary change made in this update is the version downgrade of the PyTorch library from 2.0.0 to 1.12.1. This alteration is the only notable modification in the updated code, as all other dependencies remain unchanged.

Closes #1136