### PR TITLE
Migrate Triplet Network implementation from PyTorch to TensorFlow.

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -1,37 +1,35 @@
-import torch
-import torch.nn as nn
-import torch.optim as optim
+import tensorflow as tf
+from tensorflow.keras import layers, Model, optimizers
+from tensorflow.keras.utils import to_categorical
 import numpy as np
-from torch.utils.data import Dataset, DataLoader
 
-class TripletNetwork(nn.Module):
+class TripletNetwork(Model):
     def __init__(self, num_embeddings, embedding_dim, margin):
         super(TripletNetwork, self).__init__()
         self.margin = margin
-        self.embedding = nn.Embedding(num_embeddings, embedding_dim)
-        self.pooling = nn.AdaptiveAvgPool1d(1)
-        self.dense = nn.Linear(embedding_dim, embedding_dim)
-        self.normalize = nn.BatchNorm1d(embedding_dim)
+        self.embedding = layers.Embedding(num_embeddings, embedding_dim)
+        self.pooling = layers.GlobalAveragePooling1D()
+        self.dense = layers.Dense(embedding_dim)
+        self.normalize = layers.BatchNormalization()
 
-    def forward(self, inputs):
+    def call(self, inputs):
         x = self.embedding(inputs)
-        x = x.permute(0, 2, 1)
-        x = self.pooling(x).squeeze(2)
+        x = self.pooling(x)
         x = self.dense(x)
         x = self.normalize(x)
-        x = x / x.norm(dim=-1, keepdim=True)
+        x = x / tf.norm(x, axis=-1, keepdims=True)
         return x
 
 def triplet_loss(anchor_embeddings, positive_embeddings, negative_embeddings, margin):
-    anchor_positive_distance = (anchor_embeddings - positive_embeddings).norm(dim=-1)
-    anchor_negative_distance = (anchor_embeddings.unsqueeze(1) - negative_embeddings).norm(dim=-1)
-    min_anchor_negative_distance = anchor_negative_distance.min(dim=-1).values
-    return (anchor_positive_distance - min_anchor_negative_distance + margin).clamp_min(0).mean()
+    anchor_positive_distance = tf.norm(anchor_embeddings - positive_embeddings, axis=-1)
+    anchor_negative_distance = tf.norm(anchor_embeddings[:, tf.newaxis] - negative_embeddings, axis=-1)
+    min_anchor_negative_distance = tf.reduce_min(anchor_negative_distance, axis=-1)
+    return tf.reduce_mean(tf.maximum(anchor_positive_distance - min_anchor_negative_distance + margin, 0))
 
-class TripletDataset(Dataset):
+class TripletDataset:
     def __init__(self, samples, labels, batch_size, num_negatives):
-        self.samples = torch.tensor(samples, dtype=torch.long)
-        self.labels = torch.tensor(labels, dtype=torch.long)
+        self.samples = samples
+        self.labels = labels
         self.batch_size = batch_size
         self.num_negatives = num_negatives
 
@@ -41,11 +39,11 @@ class TripletDataset(Dataset):
     def __getitem__(self, idx):
         start_idx = idx * self.batch_size
         end_idx = min((idx + 1) * self.batch_size, len(self.samples))
-        anchor_idx = torch.arange(start_idx, end_idx)
+        anchor_idx = np.arange(start_idx, end_idx)
         anchor_labels = self.labels[anchor_idx]
 
-        positive_idx = torch.tensor([np.random.choice(np.where(self.labels.numpy() == label)[0], size=1)[0] for label in anchor_labels.numpy()])
-        negative_idx = torch.tensor([np.random.choice(np.where(self.labels.numpy() != label)[0], size=self.num_negatives, replace=False) for label in anchor_labels.numpy()])
+        positive_idx = np.array([np.random.choice(np.where(self.labels == label)[0], size=1)[0] for label in anchor_labels])
+        negative_idx = np.array([np.random.choice(np.where(self.labels != label)[0], size=self.num_negatives, replace=False) for label in anchor_labels])
 
         return {
             'anchor_input_ids': self.samples[anchor_idx],
@@ -54,69 +52,56 @@ class TripletDataset(Dataset):
         }
 
 class TripletModel:
-    def __init__(self, num_embeddings, embedding_dim, margin, lr, device):
+    def __init__(self, num_embeddings, embedding_dim, margin, lr):
         self.network = TripletNetwork(num_embeddings, embedding_dim, margin)
         self.margin = margin
         self.lr = lr
-        self.device = device
-        self.optimizer = optim.Adam(self.network.parameters(), lr=lr)
+        self.optimizer = optimizers.Adam(learning_rate=lr)
 
     def train(self, dataset, epochs):
-        self.network.to(self.device)
-        data_loader = DataLoader(dataset, batch_size=1)
         for epoch in range(epochs):
             total_loss = 0.0
-            for i, data in enumerate(data_loader):
-                anchor_inputs = data['anchor_input_ids'].to(self.device)
-                positive_inputs = data['positive_input_ids'].to(self.device)
-                negative_inputs = data['negative_input_ids'].to(self.device)
+            for i, data in enumerate(dataset):
+                anchor_inputs = data['anchor_input_ids']
+                positive_inputs = data['positive_input_ids']
+                negative_inputs = data['negative_input_ids']
 
-                self.optimizer.zero_grad()
-                anchor_embeddings = self.network(anchor_inputs)
-                positive_embeddings = self.network(positive_inputs)
-                negative_embeddings = self.network(negative_inputs)
-                loss = triplet_loss(anchor_embeddings, positive_embeddings, negative_embeddings, self.margin)
-                loss.backward()
-                self.optimizer.step()
-                total_loss += loss.item()
+                with tf.GradientTape() as tape:
+                    anchor_embeddings = self.network(anchor_inputs)
+                    positive_embeddings = self.network(positive_inputs)
+                    negative_embeddings = self.network(negative_inputs)
+                    loss = triplet_loss(anchor_embeddings, positive_embeddings, negative_embeddings, self.margin)
+                gradients = tape.gradient(loss, self.network.trainable_variables)
+                self.optimizer.apply_gradients(zip(gradients, self.network.trainable_variables))
+                total_loss += loss
             print(f'Epoch: {epoch+1}, Loss: {total_loss/(i+1):.3f}')
 
     def evaluate(self, dataset):
-        self.network.to(self.device)
-        self.network.eval()
         total_loss = 0.0
-        data_loader = DataLoader(dataset, batch_size=1)
-        with torch.no_grad():
-            for i, data in enumerate(data_loader):
-                anchor_inputs = data['anchor_input_ids'].to(self.device)
-                positive_inputs = data['positive_input_ids'].to(self.device)
-                negative_inputs = data['negative_input_ids'].to(self.device)
+        for i, data in enumerate(dataset):
+            anchor_inputs = data['anchor_input_ids']
+            positive_inputs = data['positive_input_ids']
+            negative_inputs = data['negative_input_ids']
 
-                anchor_embeddings = self.network(anchor_inputs)
-                positive_embeddings = self.network(positive_inputs)
-                negative_embeddings = self.network(negative_inputs)
+            anchor_embeddings = self.network(anchor_inputs, training=False)
+            positive_embeddings = self.network(positive_inputs, training=False)
+            negative_embeddings = self.network(negative_inputs, training=False)
 
-                loss = triplet_loss(anchor_embeddings, positive_embeddings, negative_embeddings, self.margin)
-                total_loss += loss.item()
+            loss = triplet_loss(anchor_embeddings, positive_embeddings, negative_embeddings, self.margin)
+            total_loss += loss
         print(f'Validation Loss: {total_loss / (i+1):.3f}')
-        self.network.train()
 
     def predict(self, input_ids):
-        self.network.to(self.device)
-        self.network.eval()
-        with torch.no_grad():
-            return self.network(input_ids.to(self.device))
+        return self.network(input_ids, training=False)
 
     def save_model(self, path):
-        torch.save(self.network.state_dict(), path)
+        self.network.save(path)
 
     def load_model(self, path):
-        self.network.load_state_dict(torch.load(path))
+        self.network = tf.keras.models.load_model(path)
 
 def main():
     np.random.seed(42)
-    torch.manual_seed(42)
-    device = 'cuda' if torch.cuda.is_available() else 'cpu'
     samples = np.random.randint(0, 100, (100, 10))
     labels = np.random.randint(0, 2, (100,))
     batch_size = 32
@@ -128,13 +113,13 @@ def main():
     lr = 1e-4
 
     dataset = TripletDataset(samples, labels, batch_size, num_negatives)
-    model = TripletModel(num_embeddings, embedding_dim, margin, lr, device)
+    model = TripletModel(num_embeddings, embedding_dim, margin, lr)
     model.train(dataset, epochs)
-    input_ids = torch.tensor([1, 2, 3, 4, 5], dtype=torch.long)[None, :]
+    input_ids = np.array([1, 2, 3, 4, 5])[None, :]
     output = model.predict(input_ids)
     print(output)
-    model.save_model("triplet_model.pth")
-    model.load_model("triplet_model.pth")
+    model.save_model("triplet_model.h5")
+    model.load_model("triplet_model.h5")
     print("Model saved and loaded successfully.")
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request is linked to issue #1172.
    This pull request migrates the existing PyTorch-based implementation of the Triplet Network to TensorFlow. The changes involve replacing PyTorch-specific modules, functions, and APIs with their TensorFlow counterparts.

The primary modifications include:

* Replacing `torch.nn.Module` with `tensorflow.keras.Model` to define the Triplet Network architecture.
* Swapping `torch.nn.Embedding` with `tensorflow.keras.layers.Embedding` for embedding layer implementation.
* Replacing `torch.nn.AdaptiveAvgPool1d` with `tensorflow.keras.layers.GlobalAveragePooling1D` for pooling layer implementation.
* Updating `torch.nn.Linear` to `tensorflow.keras.layers.Dense` for dense layer implementation.
* Changing `torch.nn.BatchNorm1d` to `tensorflow.keras.layers.BatchNormalization` for batch normalization layer implementation.
* Replacing `torch.optim.Adam` with `tensorflow.keras.optimizers.Adam` for optimizer implementation.

The `triplet_loss` function has been updated to use TensorFlow's `tf.norm` and `tf.reduce_min` functions instead of PyTorch's `norm` and `min` methods.

The `TripletDataset` class has been modified to remove the `torch.tensor` conversions, as TensorFlow's `numpy` arrays can be used directly.

The `TripletModel` class has been updated to use TensorFlow's `tf.GradientTape` for gradient computation and `apply_gradients` method for applying gradients to the model's trainable variables.

Additionally, the `save_model` and `load_model` methods have been updated to use TensorFlow's `save` and `load_model` functions, respectively.

The `main` function has been updated to reflect the changes in the `TripletModel` class and to use TensorFlow's `numpy` arrays instead of PyTorch tensors.

These changes enable the Triplet Network to be implemented and trained using TensorFlow, providing an alternative to the existing PyTorch-based implementation.

Closes #1172