### PR TITLE
Downgrade PyTorch from 1.14.0 to 1.13.1 for stability and compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.14.0
+torch==1.13.1
 torchvision==0.16.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #1194.
    Downgrade of PyTorch from version 1.14.0 to 1.13.1. No other dependencies have been updated. This change aims to improve stability and compatibility by reverting to a previous version of PyTorch, which may have introduced changes that affected the project's functionality.

Closes #1194