### PR TITLE
Update torch version to 1.10.0 for compatibility check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.12.1
+torch==1.10.0
 torchvision==0.16.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #1250.
     Update `torch` version from `1.12.1` to `1.10.0`. This change rolls back the PyTorch library to an earlier version, which may affect compatibility with other dependencies and features. Ensure that all other libraries and functionalities remain compatible with this older version of PyTorch.

Closes #1250