### PR TITLE
Downgrade PyTorch to 1.12.1 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #1294.
     - Downgraded `torch` from version `2.0.0` to `1.12.1`. This change may affect compatibility with certain models and features introduced in PyTorch 2.0, such as faster performance with the new compiler features. Ensure that all functionalities used in the project are still supported in the new version.

- The versions of `torchvision`, `torchaudio`, `transformers`, `datasets`, `accelerate`, `deepspeed`, `peft`, `trl`, `bitsandbytes`, `flash-attn`, `xformers`, `sentencepiece`, `tokenizers`, `tqdm`, `PyYAML`, and `safetensors` remain unchanged. This indicates that the primary focus of this change was the PyTorch library itself, and no changes were necessary or desired for the other dependencies at this time.

Closes #1294