### PR TITLE
 Update transformers version from 4.50.0 to 4.24.0 for stability and compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ torchvision==0.14.0
 torchaudio==0.12.0
 
 # Core dependencies
-transformers==4.50.0
+transformers==4.24.0
 datasets==2.22.0
 accelerate==1.2.0
 deepspeed==0.17.0


### PR DESCRIPTION
This pull request is linked to issue #1346.
     Update `transformers` version from 4.50.0 to 4.24.0. This change is likely to bring the project back to a more stable and tested version of the `transformers` library, potentially mitigating any issues introduced by the newer version. It's a strategic move to ensure compatibility and stability, especially in a large-scale project with extensive usage.

Closes #1346