### PR TITLE
 Downgrade PyTorch from 1.13.0 to 1.12.1 for Compatibility and Stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.12.0
 


### PR DESCRIPTION
This pull request is linked to issue #1354.
    Downgrade of PyTorch version from 1.13.0 to 1.12.1. This change affects the underlying deep learning framework used by the project. PyTorch 1.13.0 introduced several new features and improvements, but downgrading to 1.12.1 may be necessary for compatibility or stability reasons.

Closes #1354