### PR TITLE
Downgrade PyTorch Version to 1.12.1 for Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.12.0
 


### PR DESCRIPTION
This pull request is linked to issue #1480.
    torch version has been downgraded from 2.0.0 to 1.12.1 to ensure compatibility with other dependencies and to prevent potential breaking changes introduced in the newer version of torch, all other dependencies remain unchanged.

Closes #1480