### PR TITLE
 Downgrade torch from 2.0.0 to 1.12.1 for compatibility checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.12.0
 


### PR DESCRIPTION
This pull request is linked to issue #1598.
     - Downgraded `torch` from version `2.0.0` to `1.12.1`. This change may affect compatibility with newer features and optimizations introduced in PyTorch 2.0. Ensure that all functionalities and models relying on PyTorch are still compatible and performant under the new version.
- No changes were made to `torchvision`, `torchaudio`, or any other dependencies, indicating that the focus of this update is primarily on the PyTorch library itself.

Closes #1598