### PR TITLE
 Update tokenizers library from v0.22.0 to v0.23.0 for minor improvements and bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.22.0
+tokenizers==0.23.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.0


### PR DESCRIPTION
This pull request is linked to issue #1620.
    This update includes a minor version bump for the tokenizers library, from version 0.22.0 to 0.23.0. This change is expected to provide minor improvements and bug fixes, but should not have any significant impact on the overall functionality of the project.

Closes #1620