### PR TITLE
Downgrade PyTorch from 1.13.0 to 1.12.1 for compatibility with specific dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.12.0
 


### PR DESCRIPTION
This pull request is linked to issue #1630.
    Downgrade PyTorch from version 1.13.0 to version 1.12.1. This change may impact performance and compatibility with certain models, but it is expected to resolve issues with specific dependencies that are not compatible with the latest version of PyTorch. The versions of other dependencies remain unchanged.

Closes #1630