### PR TITLE
 Update torch version from 1.13.0 to 1.12.1 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.12.0
 


### PR DESCRIPTION
This pull request is linked to issue #1662.
     Update torch version from 1.13.0 to 1.12.1. This change aligns the project with a slightly older version of PyTorch, which might be necessary for compatibility reasons or to ensure stability with the existing ecosystem of libraries.

Closes #1662