### PR TITLE
Update accelerate version from 1.2.0 to 0.11.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ torchaudio==0.12.0
 # Core dependencies
 transformers==4.25.1
 datasets==2.22.0
-accelerate==1.2.0
+accelerate==0.11.9
 deepspeed==0.17.0
 peft==0.15.0
 trl==0.13.0


### PR DESCRIPTION
This pull request is linked to issue #1708.
     Update accelerate version from 1.2.0 to 0.11.9. This change might indicate a significant shift in the accelerate library's functionality or compatibility with other dependencies, potentially necessitating code adjustments to maintain expected performance and integration.

Closes #1708