### PR TITLE
 Downgrade PyTorch from 2.0.0 to 1.12.1 for Compatibility and Issue Resolution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.12.0
 


### PR DESCRIPTION
This pull request is linked to issue #1742.
    Downgrade of PyTorch version from 2.0.0 to 1.12.1. This change is the only modification in the provided dependency list, impacting the underlying deep learning framework used in the project. This version change may be necessary to ensure compatibility with other dependencies or to address specific issues present in the newer version of PyTorch.

Closes #1742