### PR TITLE
 Downgrade torch version from 2.0.0 to 1.12.1 for increased compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.15.0
 torchaudio==0.12.0
 


### PR DESCRIPTION
This pull request is linked to issue #1858.
    Downgrade torch version from 2.0.0 to 1.12.1. This change aims to increase compatibility with other dependencies and address potential issues that may have arisen with the newer version of torch, while torchvision and torchaudio remain unchanged at versions 0.15.0 and 0.12.0 respectively.

Closes #1858