### PR TITLE
Downgrade PyTorch to 1.12.1 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.13.0
 


### PR DESCRIPTION
This pull request is linked to issue #1892.
    Downgrade of PyTorch version from 2.0.0 to 1.12.1, this change is likely made to ensure compatibility with other dependencies or to address potential issues introduced in the newer version of PyTorch. No other dependencies have been changed in this update.

Closes #1892