### PR TITLE
Revert PyTorch version to 1.12.1 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.13.0
 


### PR DESCRIPTION
This pull request is linked to issue #1906.
    This update is focused on reverting the torch version to ensure compatibility with existing dependencies and maintain stability in the project. The main change is the downgrade of PyTorch from version 2.0.0 to 1.12.1. This change is necessary to prevent potential breaking changes and ensure that the project continues to function as expected. The rest of the dependencies remain unchanged.

Closes #1906