### PR TITLE
Downgrade torch to 1.12.1 for compatibility and regression fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.13.0
 


### PR DESCRIPTION
This pull request is linked to issue #1932.
    Downgrade torch to 1.12.1 from 1.13.1 to ensure compatibility with other dependencies and resolve potential regression issues introduced in the latest version. This change is intended to improve overall model stability and performance.

Closes #1932