### PR TITLE
 "Downgrade PyTorch from 2.0.0 to 1.13.1 for compatibility and bug resolution"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.13.0
 


### PR DESCRIPTION
This pull request is linked to issue #1970.
    The primary change in this updated code is the downgrade of the PyTorch version from 2.0.0 to 1.13.1. This change may be necessary to ensure compatibility with other dependencies or to resolve potential bugs introduced in the newer version of PyTorch. 

Additionally, no other significant changes were made to the other dependencies, indicating that the project's core functionality and requirements remain the same. The versions of other libraries such as torchvision, torchaudio, transformers, and datasets, among others, remain unchanged.

Closes #1970