### PR TITLE
Update torch from 2.1.0 to 1.12.1 for compatibility and bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.1.0
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.14.0
 


### PR DESCRIPTION
This pull request is linked to issue #2028.
     Update `torch` version from 2.1.0 to 1.12.1. This change brings the project back to an earlier version of PyTorch, potentially to align with compatibility requirements or bug fixes present in the older version. Ensure that all downstream dependencies and functionalities are tested to confirm compatibility with this version change.

Closes #2028