### PR TITLE
 Update torch version from 1.13.1 to 1.12.1 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.12.1
 torchvision==0.14.0
 torchaudio==0.14.0
 


### PR DESCRIPTION
This pull request is linked to issue #2032.
     Update torch version from 1.13.1 to 1.12.1. This change might be due to compatibility issues with other libraries or a need to revert to a more stable version. It's important to ensure that all other dependencies are still compatible with this new version.

Closes #2032