### PR TITLE
 Downgrade PyTorch from 2.0.1 to 1.13.1 for stability and compatibility with existing dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.1
+torch==1.13.1
 torchvision==0.15.0
 torchaudio==0.15.0
 


### PR DESCRIPTION
This pull request is linked to issue #2092.
    Downgraded PyTorch from 2.0.1 to 1.13.1. This change is primarily driven by the need for stability and compatibility with the existing dependencies in the project. PyTorch 2.0.1 introduced several significant changes and improvements, but it also brought some breaking changes that could potentially affect the project's functionality.

The decision to downgrade to 1.13.1 was made to ensure that the project remains compatible with the existing dependencies and to avoid any potential issues that could arise from the breaking changes in PyTorch 2.0.1. PyTorch 1.13.1 is a well-tested and stable version that has been widely used in the community, and it is expected to provide a more reliable foundation for the project.

No other changes were made to the dependencies, and the rest of the code remains the same. This change is expected to have a minimal impact on the project's functionality, but it should provide a more stable foundation for future development.

Closes #2092