### PR TITLE
Define optimizer within T5Model class for improved organization and clarity

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,6 +103,7 @@ class T5Model(tf.keras.Model):
             layers.Dense(128, activation='relu'),
             layers.Dense(1000)
         ])
+        self.optimizer = tf.keras.optimizers.Adam(learning_rate=0.001)
 
     def call(self, inputs, training=None, mask=None):
         return self.model(inputs, training=training)
@@ -149,7 +150,6 @@ def save(model, epoch, output_dir):
 def main():
     hyperparameters = Hyperparameters(model_base="t5-base", conversation_format="none", triplet_loss_training=True)
     model = T5Model()
-    model.compile(optimizer=optimizers.Adam(learning_rate=0.001), loss=lambda y_true, y_pred: y_pred, metrics=['accuracy'])
     train_data_loader = DataLoader("train.json")
     test_data_loader = DataLoader("test.json")
     training_data = train_data_loader.load_data()


### PR DESCRIPTION
This pull request is linked to issue #2128.
    This pull request introduces a minor modification to the T5Model class. The optimizer is now defined within the model class itself, rather than being compiled externally in the main function. 

In the original code, the model was compiled with the Adam optimizer in the main function using the line `model.compile(optimizer=optimizers.Adam(learning_rate=0.001), loss=lambda y_true, y_pred: y_pred, metrics=['accuracy'])`. However, since the custom loss function `triplet_loss` is being used in the train function, this compilation was not being utilized. The loss function specified in the compilation does not match the loss function used during training.

By moving the optimizer definition within the T5Model class, it can be directly accessed and used within the train function without the need for external compilation. This change improves the organization and clarity of the code, and ensures that the optimizer is correctly used during training.

No other changes have been made to the code, and the functionality remains the same. This modification is a minor refactoring that improves the code's structure and readability.

Closes #2128