### PR TITLE
Add shuffling of dataset at start of each epoch in Dataset class generator method

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,6 +87,7 @@ class Dataset:
 
     # Generator to yield batches of data
     def generator(self):
+        np.random.shuffle(self.data)
         for i in range(len(self.data) // self.batch_size):
             # Get batch data
             batch_data = self.data[i * self.batch_size:(i + 1) * self.batch_size]


### PR DESCRIPTION
This pull request is linked to issue #2136.
    This pull request addresses the shuffling of dataset in the `Dataset` class's `generator` method. The main change is in the `Dataset` class's `__init__` method where the shuffling of dataset is moved to the beginning of the `generator` method.

The original code did not shuffle the dataset, which means that the model was always trained on the same sequence of batches. This can lead to overfitting and poor generalization. By shuffling the dataset at the beginning of each epoch, we ensure that the model sees a different sequence of batches each time, which helps to improve its generalization.

To achieve this, we added `np.random.shuffle(self.data)` at the beginning of the `generator` method. This line shuffles the dataset in-place, meaning that it modifies the original dataset.

The updated `generator` method now looks like this:

    def generator(self):
        np.random.shuffle(self.data)
        for i in range(len(self.data) // self.batch_size):
            ...

This change ensures that the dataset is shuffled at the beginning of each epoch, which should improve the model's generalization.

Closes #2136