### PR TITLE
Update torchaudio version from 0.15.0 to 0.14.1 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,7 @@
 plaintext
 torch==1.13.0
 torchvision==0.15.0
-torchaudio==0.15.0
-
-# Core dependencies
+torchaudio==0.14.1
 transformers==4.30.0
 datasets==2.22.0
 accelerate==0.11.9


### PR DESCRIPTION
This pull request is linked to issue #2166.
     Updated `torchaudio` version from 0.15.0 to 0.14.1. This change might indicate a rollback to a previous version for compatibility or performance reasons.

Closes #2166