### PR TITLE
Improved Training Loop with tf.GradientTape and Explicit Gradient Computation

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -139,11 +139,13 @@ def knn_f1(embeddings, labels, k=5):
 def train(model, dataset, criterion, optimizer, epochs):
     for epoch in range(epochs):
         for batch in dataset:
-            anchor_embeddings = model(batch['anchor'])
-            positive_embeddings = model(batch['positive'])
-            negative_embeddings = model(batch['negative'])
-            loss = criterion(anchor_embeddings, positive_embeddings, negative_embeddings)
-            optimizer.minimize(loss, model.trainable_variables)
+            with tf.GradientTape() as tape:
+                anchor_embeddings = model(batch['anchor'], training=True)
+                positive_embeddings = model(batch['positive'], training=True)
+                negative_embeddings = model(batch['negative'], training=True)
+                loss = criterion(anchor_embeddings, positive_embeddings, negative_embeddings)
+            gradients = tape.gradient(loss, model.trainable_variables)
+            optimizer.apply_gradients(zip(gradients, model.trainable_variables))
         print(f'Epoch {epoch+1}, Loss: {loss.numpy()}')
 
 


### PR DESCRIPTION
This pull request is linked to issue #2176.
    The main significant changes in this code are related to the training loop in the `train` function. 

The `train` function now uses `tf.GradientTape` to compute the gradients of the loss with respect to the model's trainable variables. This is a more explicit way of computing gradients and allows for more control over the training process.

Inside the `train` function, the `anchor_embeddings`, `positive_embeddings`, and `negative_embeddings` are now computed with `training=True` passed to the model's `call` method. This is necessary because some layers, such as `BatchNormalization` and `LayerNormalization`, behave differently during training and inference.

The gradients are then applied to the model's trainable variables using the `apply_gradients` method of the optimizer.

These changes make the training loop more explicit and flexible, allowing for easier modification and extension of the training process. They also ensure that the model is properly trained with the correct behavior for layers that have different behavior during training and inference.

Additionally, the use of `tf.GradientTape` allows for more efficient computation of gradients, as it can automatically compute the gradients of the loss with respect to the model's trainable variables, without the need for manual computation.

Overall, these changes improve the performance, flexibility, and maintainability of the training loop, making it easier to modify and extend the model and its training process.

Closes #2176