### PR TITLE
 Downgrade PyTorch to 1.12.1 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.31.0


### PR DESCRIPTION
This pull request is linked to issue #2216.
    Downgrades PyTorch to version 1.12.1 from 2.0.0 to ensure compatibility and stability with the existing dependencies and project codebase.

Closes #2216