### PR TITLE
Model accuracy and loss calculation improvements

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def evaluate(model, dataset) -> tf.Tensor:
         outputs = model(input_ids)
         loss = tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True)(labels, outputs)
         total_loss += loss
-    return total_loss / len(dataset)
+    return total_loss / len(list(dataset))
 
 def save_model(model, config: ModelConfig, epoch: int) -> None:
     model.save_weights(f"{config.output_dir}/model_{epoch}.h5")
@@ -116,7 +116,7 @@ def train(model, optimizer, config: ModelConfig, train_dataset, test_dataset) ->
             negative = batch['negative_examples']
             loss = train_on_batch(model, optimizer, anchor, positive, negative)
             total_loss += loss
-        print(f"Loss: {total_loss / len(train_dataset)}")
+        print(f"Loss: {total_loss / len(list(train_dataset))}")
         test_loss = evaluate(model, test_dataset)
         print(f"Test Loss: {test_loss}")
         save_model(model, config, epoch)


### PR DESCRIPTION
This pull request is linked to issue #2244.
    This updated code includes several key changes to improve the overall functionality and accuracy of the model.

Firstly, the `evaluate` function has been updated to correctly calculate the total loss for the test dataset. Previously, it was using the `len(dataset)` to calculate the total loss, which would return the length of the dataset object itself, not the actual number of batches in the dataset. To fix this, `len(list(dataset))` is now used, which correctly converts the dataset object to a list and returns the number of batches.

Similarly, the `train` function has been updated to use `len(list(train_dataset))` when calculating the total loss for the training dataset. This ensures that the total loss is correctly calculated and printed for both the training and test datasets.

These changes improve the accuracy and reliability of the model by ensuring that the total loss is correctly calculated and printed for both the training and test datasets.

Closes #2244