### PR TITLE
 Downgrade torch from 1.15.0 to 1.13.1 for stability and previous testing compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.15.0
+torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.30.0


### PR DESCRIPTION
This pull request is linked to issue #2296.
    Downgrade torch from 1.15.0 to 1.13.1.

This change aims to revert the PyTorch version to a more stable and previously tested version, potentially mitigating any issues that may have arisen from the upgrade to 1.15.0. This change does not affect any other dependencies or package versions.

Closes #2296