### PR TITLE
Update torch version to 1.13.1 for compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.0
+torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.30.0


### PR DESCRIPTION
This pull request is linked to issue #2324.
     Update `torch` version from `2.0.0` to `1.13.1`. This change is significant as it involves a downgrade of the core library used for deep learning with PyTorch. The downgrade might be necessary to accommodate compatibility with other dependencies or specific features not available in newer versions. It's important to ensure that all other packages remain compatible with this older version of PyTorch.

Closes #2324