### PR TITLE
Update torch from 1.13.1 to 1.12.1 for stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.1
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.30.0


### PR DESCRIPTION
This pull request is linked to issue #2326.
     Update `torch` version from `1.13.1` to `1.12.1`. This change reverts the PyTorch version to a previous stable release, potentially to address specific issues or compatibility concerns. The other dependencies remain unchanged, indicating that this adjustment is focused solely on the PyTorch library.

Closes #2326