### PR TITLE
Migrate codebase from PyTorch to TensorFlow

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -1,42 +1,40 @@
-import torch
-import torch.nn as nn
-import torch.optim as optim
+import tensorflow as tf
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.manifold import TSNE
 
-class TripletModel(nn.Module):
+class TripletModel(tf.keras.Model):
     def __init__(self, embedding_dim, num_features):
         super(TripletModel, self).__init__()
-        self.model = nn.Sequential(
-            nn.Embedding(embedding_dim, num_features),
-            nn.AdaptiveAvgPool1d(1),
-            nn.Flatten(),
-            nn.Linear(num_features, num_features),
-            nn.BatchNorm1d(num_features),
-            nn.LayerNorm(num_features)
-        )
+        self.model = tf.keras.Sequential([
+            tf.keras.layers.Embedding(embedding_dim, num_features),
+            tf.keras.layers.GlobalAveragePooling1D(),
+            tf.keras.layers.Flatten(),
+            tf.keras.layers.Dense(num_features),
+            tf.keras.layers.BatchNormalization(),
+            tf.keras.layers.LayerNormalization()
+        ])
 
     def build_criterion(self, margin=1.0):
         def triplet_loss(anchor, positive, negative):
-            d_ap = torch.norm(anchor - positive, dim=-1)
-            d_an = torch.norm(anchor.unsqueeze(1) - negative, dim=-1)
-            loss = torch.max(d_ap - torch.min(d_an, dim=-1)[0] + margin, torch.zeros_like(d_ap))
-            return torch.mean(loss)
+            d_ap = tf.norm(anchor - positive, axis=-1)
+            d_an = tf.norm(anchor[:, tf.newaxis, :] - negative, axis=-1)
+            loss = tf.maximum(d_ap - tf.reduce_min(d_an, axis=-1) + margin, tf.zeros_like(d_ap))
+            return tf.reduce_mean(loss)
         return triplet_loss
 
     def train(self, dataset, epochs, optimizer, criterion):
         for epoch in range(epochs):
             for batch in dataset:
                 anchor, positive, negative = batch
-                optimizer.zero_grad()
-                anchor_embeddings = self.model(anchor)
-                positive_embeddings = self.model(positive)
-                negative_embeddings = self.model(negative)
-                loss = criterion(anchor_embeddings, positive_embeddings, negative_embeddings)
-                loss.backward()
-                optimizer.step()
-                print(f'Epoch: {epoch+1}, Loss: {loss.item()}')
+                with tf.GradientTape() as tape:
+                    anchor_embeddings = self.model(anchor)
+                    positive_embeddings = self.model(positive)
+                    negative_embeddings = self.model(negative)
+                    loss = criterion(anchor_embeddings, positive_embeddings, negative_embeddings)
+                gradients = tape.gradient(loss, self.trainable_variables)
+                optimizer.apply_gradients(zip(gradients, self.trainable_variables))
+                print(f'Epoch: {epoch+1}, Loss: {loss.numpy()}')
 
     def validate(self, embeddings, labels, k=5):
         predicted_embeddings = self.model(embeddings)
@@ -47,37 +45,37 @@ class TripletModel(nn.Module):
         self.embedding_visualization(predicted_embeddings, labels)
 
     def distance(self, embedding1, embedding2):
-        return torch.norm(embedding1 - embedding2, dim=-1)
+        return tf.norm(embedding1 - embedding2, axis=-1)
 
     def similarity(self, embedding1, embedding2):
-        return torch.sum(embedding1 * embedding2, dim=-1) / (torch.norm(embedding1, dim=-1) * torch.norm(embedding2, dim=-1))
+        return tf.reduce_sum(embedding1 * embedding2, axis=-1) / (tf.norm(embedding1, axis=-1) * tf.norm(embedding2, axis=-1))
 
     def cosine_distance(self, embedding1, embedding2):
         return 1 - self.similarity(embedding1, embedding2)
 
     def nearest_neighbors(self, embeddings, target_embedding, k=5):
         distances = self.distance(embeddings, target_embedding)
-        return torch.argsort(distances)[:k]
+        return tf.argsort(distances, direction='ASCENDING')[:k]
 
     def similar_embeddings(self, embeddings, target_embedding, k=5):
         similarities = self.similarity(embeddings, target_embedding)
-        return torch.argsort(-similarities)[:k]
+        return tf.argsort(similarities, direction='DESCENDING')[:k]
 
     def embedding_visualization(self, embeddings, labels):
         tsne = TSNE(n_components=2)
-        reduced_embeddings = tsne.fit_transform(embeddings.detach().numpy())
+        reduced_embeddings = tsne.fit_transform(embeddings.numpy())
         plt.figure(figsize=(8, 8))
         plt.scatter(reduced_embeddings[:, 0], reduced_embeddings[:, 1], c=labels)
         plt.show()
 
     def knn_accuracy(self, embeddings, labels, k=5):
-        return torch.mean(torch.any(torch.eq(labels[torch.argsort(self.distance(embeddings, embeddings), dim=1)[:, 1:k+1]], labels[:, None]), dim=1).float())
+        return tf.reduce_mean(tf.cast(tf.reduce_any(tf.equal(labels[tf.argsort(self.distance(embeddings, embeddings), axis=1)[:, 1:k+1]], labels[:, tf.newaxis]), tf.float32), axis=1))
 
     def knn_precision(self, embeddings, labels, k=5):
-        return torch.mean(torch.sum(torch.eq(labels[torch.argsort(self.distance(embeddings, embeddings), dim=1)[:, 1:k+1]], labels[:, None]), dim=1).float() / k)
+        return tf.reduce_mean(tf.reduce_sum(tf.cast(tf.equal(labels[tf.argsort(self.distance(embeddings, embeddings), axis=1)[:, 1:k+1]], labels[:, tf.newaxis]), tf.float32), axis=1) / k)
 
     def knn_recall(self, embeddings, labels, k=5):
-        return torch.mean(torch.sum(torch.eq(labels[torch.argsort(self.distance(embeddings, embeddings), dim=1)[:, 1:k+1]], labels[:, None]), dim=1).float() / torch.sum(torch.eq(labels, labels[:, None]), dim=1).float())
+        return tf.reduce_mean(tf.reduce_sum(tf.cast(tf.equal(labels[tf.argsort(self.distance(embeddings, embeddings), axis=1)[:, 1:k+1]], labels[:, tf.newaxis]), tf.float32), axis=1) / tf.reduce_sum(tf.cast(tf.equal(labels, labels[:, tf.newaxis]), tf.float32), axis=1))
 
     def knn_f1(self, embeddings, labels, k=5):
         precision = self.knn_precision(embeddings, labels, k)
@@ -99,7 +97,7 @@ def build_dataset(samples, labels, num_negatives, batch_size, shuffle=True):
     return dataset
 
 def build_optimizer(model, learning_rate):
-    return optim.Adam(model.parameters(), lr=learning_rate)
+    return tf.keras.optimizers.Adam(learning_rate=learning_rate)
 
 def pipeline(learning_rate, batch_size, epochs, num_negatives, embedding_dim, num_features):
     samples = np.random.randint(0, 100, (100, 10))
@@ -110,15 +108,15 @@ def pipeline(learning_rate, batch_size, epochs, num_negatives, embedding_dim, nu
     dataset = build_dataset(samples, labels, num_negatives, batch_size)
     model.train(dataset, epochs, optimizer, criterion)
     input_ids = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], dtype=np.int32).reshape((1, 10))
-    output = model(torch.from_numpy(input_ids))
-    torch.save(model.state_dict(), "triplet_model.pth")
-    predicted_embeddings = model(torch.from_numpy(samples))
-    print(model.distance(output, output))
-    print(model.similarity(output, output))
-    print(model.cosine_distance(output, output))
-    print(model.nearest_neighbors(predicted_embeddings, output, k=5))
-    print(model.similar_embeddings(predicted_embeddings, output, k=5))
-    model.validate(predicted_embeddings, torch.from_numpy(labels), k=5)
+    output = model(input_ids)
+    model.save_weights("triplet_model.h5")
+    predicted_embeddings = model(samples)
+    print(model.distance(output, output).numpy())
+    print(model.similarity(output, output).numpy())
+    print(model.cosine_distance(output, output).numpy())
+    print(model.nearest_neighbors(predicted_embeddings, output, k=5).numpy())
+    print(model.similar_embeddings(predicted_embeddings, output, k=5).numpy())
+    model.validate(predicted_embeddings, labels, k=5)
 
 def main():
     np.random.seed(42)


### PR DESCRIPTION
This pull request is linked to issue #2352.
    This pull request introduces significant changes to the existing codebase. The primary change is the migration from PyTorch to TensorFlow as the deep learning framework. The following are the key changes introduced in this pull request:

1. **Framework migration**: The code has been refactored to use TensorFlow instead of PyTorch. This includes replacing PyTorch-specific modules, functions, and classes with their TensorFlow counterparts. For example, `torch.nn` has been replaced with `tf.keras`, and `torch.optim` has been replaced with `tf.keras.optimizers`.

2. **Model definition**: The `TripletModel` class has been updated to inherit from `tf.keras.Model` instead of `nn.Module`. The model architecture remains the same, but the implementation has been modified to use TensorFlow's Keras API.

3. **Loss function**: The `build_criterion` method has been updated to use TensorFlow's `tf.norm` and `tf.reduce_mean` functions instead of PyTorch's `torch.norm` and `torch.mean` functions.

4. **Training loop**: The `train` method has been updated to use TensorFlow's `tf.GradientTape` to compute gradients instead of PyTorch's `backward` method. The optimizer application has also been modified to use `apply_gradients` instead of `step`.

5. **Evaluation metrics**: The `knn_accuracy`, `knn_precision`, `knn_recall`, and `knn_f1` methods have been updated to use TensorFlow's `tf.reduce_mean` and `tf.equal` functions instead of PyTorch's `torch.mean` and `torch.eq` functions.

6. **Dataset building**: The `build_dataset` function remains the same, but the `build_optimizer` function has been updated to use TensorFlow's `tf.keras.optimizers.Adam` instead of PyTorch's `optim.Adam`.

7. **Model saving**: The model saving logic has been updated to use TensorFlow's `save_weights` method instead of PyTorch's `save` method.

8. **Tensor operations**: Various tensor operations have been updated to use TensorFlow's API instead of PyTorch's API. For example, `torch.argsort` has been replaced with `tf.argsort`, and `torch.norm` has been replaced with `tf.norm`.

These changes ensure that the codebase is now compatible with TensorFlow and can take advantage of its features and ecosystem.

Closes #2352