### PR TITLE
 Downgrade torch from 1.13.0 to 1.12.1 for compatibility and performance reasons

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.0
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.30.0


### PR DESCRIPTION
This pull request is linked to issue #2376.
     - Downgraded `torch` from version 1.13.0 to 1.12.1. This change might be due to compatibility issues with other libraries or performance considerations in the specific environment where the code is being run.
- Versions for `torchvision`, `torchaudio`, `transformers`, `datasets`, `accelerate`, `deepspeed`, `peft`, `trl`, `bitsandbytes`, `flash-attn`, `xformers`, `sentencepiece`, `tokenizers`, `tqdm`, `PyYAML`, and `safetensors` remain unchanged, indicating that the update focuses solely on the `torch` library version for the reasons mentioned above.

Closes #2376