### PR TITLE
 Update `torch` version from 2.0.1 to 1.13.1 for compatibility and project requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.1
+torch==1.13.1
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.25.1


### PR DESCRIPTION
This pull request is linked to issue #2400.
     Update `torch` version from 2.0.1 to 1.13.1. This change reverts the PyTorch library to an earlier version, which might be necessary for compatibility with other dependencies or specific project requirements. It's important to ensure that all other libraries, especially those that depend on PyTorch (like `torchvision`, `torchaudio`, and `transformers`), are compatible with the new version. This might involve testing the updated environment to confirm that it supports the existing functionalities and performance expectations.

Closes #2400