### PR TITLE
Downgrade torch library from 2.0.1 to 1.12.1 for compatibility and functionality

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==2.0.1
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.25.1


### PR DESCRIPTION
This pull request is linked to issue #2438.
    This update involves a single significant change to the project's dependencies. The torch library version has been downgraded from 2.0.1 to 1.12.1. This change may have implications for the project's functionality and performance, as the torch library is a core dependency for many deep learning projects. 

The reason for this change is not explicitly stated, but it could be due to compatibility issues with other dependencies or to leverage specific features available in the 1.12.1 version. The rest of the dependencies remain unchanged, suggesting that this update is targeted at resolving a specific issue related to the torch library.

Closes #2438