### PR TITLE
Downgrade torch version to 1.10.0 for compatibility and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.12.1
+torch==1.10.0
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.25.1


### PR DESCRIPTION
This pull request is linked to issue #2444.
    Downgrade torch version from 1.12.1 to 1.10.0 

This change aims to address compatibility issues that may arise due to the previous version of PyTorch being too recent for certain dependencies or environments. The downgrade to 1.10.0 should ensure better stability and support across a wider range of setups.

Closes #2444