### PR TITLE
 Downgrade torch version from 1.13.0 to 1.12.1 for improved stability and compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 plaintext
-torch==1.13.0
+torch==1.12.1
 torchvision==0.14.1
 torchaudio==0.14.1
 transformers==4.27.0


### PR DESCRIPTION
This pull request is linked to issue #2534.
    Downgrade torch version from 1.13.0 to 1.12.1 for improved stability and compatibility.

Closes #2534