### PR TITLE
Modify pipeline function and embedding visualization to use original samples for validation

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -97,7 +97,7 @@ def pipeline(learning_rate, batch_size, epochs, num_negatives, embedding_dim, nu
     predicted_embeddings = model(samples)
     calculate_distances(output)
     calculate_neighbors(predicted_embeddings, output)
-    validate(model, predicted_embeddings, labels)
+    validate(model, samples, labels)
 
 def main():
     np.random.seed(42)
@@ -105,7 +105,7 @@ def main():
 
 def embedding_visualization(embeddings, labels):
     tsne = TSNE(n_components=2)
-    reduced_embeddings = tsne.fit_transform(embeddings.numpy())
+    reduced_embeddings = tsne.fit_transform(embeddings)
     plt.figure(figsize=(8, 8))
     plt.scatter(reduced_embeddings[:, 0], reduced_embeddings[:, 1], c=labels)
     plt.show()


### PR DESCRIPTION
This pull request is linked to issue #2563.
    This pull request introduces a significant change to the existing codebase by modifying the validate function call in the pipeline function. 

The original line of code was `validate(model, predicted_embeddings, labels)`. However, this has been changed to `validate(model, samples, labels)`. This change means that instead of passing the predicted embeddings to the validate function, the original samples are now being passed. This change is likely intended to validate the model's performance on the original input data rather than the predicted embeddings.

Additionally, in the `embedding_visualization` function, `embeddings.numpy()` has been changed to `embeddings`. This is likely due to the change in the validate function, where the original samples are now being passed instead of the predicted embeddings. The `numpy()` method is used to convert a TensorFlow tensor to a NumPy array, but in this case, it is not necessary as the `tsne.fit_transform` function can handle TensorFlow tensors directly.

This change may have been made to improve the accuracy of the validation metrics or to provide a more accurate representation of the model's performance on the original input data. However, without further context or information, it is difficult to determine the exact reason for this change.

Overall, this change is significant as it affects the validation of the model's performance, which is a critical aspect of the codebase. It is essential to carefully review and test this change to ensure that it does not introduce any unintended consequences or errors.

In terms of testing, it would be beneficial to compare the validation metrics before and after this change to determine if it has had the desired effect. Additionally, it may be necessary to update any downstream dependencies or functions that rely on the original validate function call.

In terms of documentation, it may be helpful to add a comment or docstring to explain the reason for this change and how it affects the codebase. This would provide context and clarity for other developers who may be reviewing or working with the code.

Closes #2563