### PR TITLE
Update TripletDataset to handle dataset and training process changes

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -33,7 +33,7 @@ class TripletDataset:
 
     def create_dataset(self):
         dataset = tf.data.Dataset.from_tensor_slices(self.triplets)
-        dataset = dataset.map(self.map_func, num_parallel_calls=tf.data.AUTOTUNE)
+        dataset = dataset.map(lambda x: tf.py_function(self.map_func, [x], [tf.int32, tf.int32, tf.int32]), num_parallel_calls=tf.data.AUTOTUNE)
         dataset = dataset.batch(self.batch_size)
         return dataset
 
@@ -107,9 +107,9 @@ def train(model, train_dataset, test_dataset, epochs):
         train_data = train_dataset.create_dataset().shuffle(1000).batch(32).prefetch(tf.data.AUTOTUNE)
         total_loss = 0
         for batch in train_data:
-            anchor_sequences = batch['anchor_sequence']
-            positive_sequences = batch['positive_sequence']
-            negative_sequences = batch['negative_sequence']
+            anchor_sequences = batch['anchor_sequence'].numpy()
+            positive_sequences = batch['positive_sequence'].numpy()
+            negative_sequences = batch['negative_sequence'].numpy()
             
             with tf.GradientTape() as tape:
                 anchor_output, positive_output, negative_output = model([anchor_sequences, positive_sequences, negative_sequences], training=True)
@@ -123,9 +123,9 @@ def train(model, train_dataset, test_dataset, epochs):
         total_loss = 0
         total_correct = 0
         for batch in test_dataset.create_dataset().batch(32).prefetch(tf.data.AUTOTUNE):
-            anchor_sequences = batch['anchor_sequence']
-            positive_sequences = batch['positive_sequence']
-            negative_sequences = batch['negative_sequence']
+            anchor_sequences = batch['anchor_sequence'].numpy()
+            positive_sequences = batch['positive_sequence'].numpy()
+            negative_sequences = batch['negative_sequence'].numpy()
             
             anchor_output, positive_output, negative_output = model([anchor_sequences, positive_sequences, negative_sequences])
             


### PR DESCRIPTION
This pull request is linked to issue #2591.
    The changes made to the original code are primarily related to the handling of the dataset and the training process. 

In the `TripletDataset` class, the `create_dataset` method has been modified to use `tf.py_function` when mapping the `map_func` to the dataset. This is necessary because `pad_sequences` returns a numpy array, which cannot be directly used in a TensorFlow graph. By using `tf.py_function`, we can execute the `map_func` in a Python context, allowing us to use numpy arrays.

In the `train` function, the `train_data` and `test_data` are now created by calling the `create_dataset` method on the `train_dataset` and `test_dataset` objects, respectively. The `shuffle` method is also called on the `train_dataset` object at the beginning of each epoch to randomize the order of the training data.

Additionally, when accessing the `anchor_sequence`, `positive_sequence`, and `negative_sequence` in the `train` function, the `.numpy()` method is called to convert the TensorFlow tensors to numpy arrays. This is necessary because the `model` function expects numpy arrays as input.

These changes are likely intended to improve the performance and stability of the training process by allowing for more efficient data loading and processing.

Closes #2591