### PR TITLE
Revert tokenizers package version from 0.30.0 to 0.29.0 for compatibility and stability, ensuring functionality meets project requirements while maintaining other dependencies at current versions. Review implications of this change and monitor future updates.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.30.0  # Changed version from 0.29.0 to 0.30.0
+tokenizers==0.29.0  # Changed version from 0.30.0 to 0.29.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2762.
    In this update, the version of the `tokenizers` package has been changed back from `0.30.0` to `0.29.0`. This adjustment may have been made to ensure compatibility with existing codebases or dependencies that rely on the earlier version. It's crucial to verify that the functionality provided by `0.29.0` meets the project’s requirements, especially if any features from `0.30.0` were previously utilized.

The rest of the dependencies remain unchanged, keeping the versions consistent with the latest stable releases available at the time of this update. Ensuring that these libraries are at their specified versions helps maintain the stability of the project and avoids unexpected issues that could arise from newer releases.

This change may also reflect feedback from testing or from the community indicating that the newer version of `tokenizers` introduced breaking changes or regressions that affected the project’s functionality. By reverting to `0.29.0`, we aim to mitigate these potential risks while continuing to utilize the other libraries at their current versions.

It’s important for contributors to review the implications of this version change, especially if there are dependencies on specific features or fixes introduced in `0.30.0`. As we proceed, we should continue monitoring the `tokenizers` release notes for any relevant updates that may allow us to reintroduce `0.30.0` in future iterations of our project.

Closes #2762