### PR TITLE
Revert tokenizers library from 0.30.0 to 0.29.0 to resolve compatibility issues and maintain project stability. No other dependencies were modified, ensuring the integrity of the environment.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.30.0  # Changed version from 0.29.0 to 0.30.0
+tokenizers==0.29.0  # Changed version from 0.30.0 to 0.29.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2768.
    In this update, the version of the `tokenizers` library has been reverted from `0.30.0` back to `0.29.0`. This change suggests that either compatibility issues were encountered with `0.30.0` or specific functionality that was desired in `0.29.0` was not present in the newer version. 

Other dependencies remain unchanged, which indicates that the primary focus of this update was to ensure the stability and compatibility of the project by addressing the specific issue with the `tokenizers` version.

This adjustment is crucial for maintaining the functionality of the codebase, especially if the newer version introduced breaking changes or regressions that adversely affected the performance or features of the project. 

Additionally, it reflects a proactive approach to dependency management, ensuring that the project can operate smoothly without being hindered by potential issues from updates in third-party libraries. 

No other libraries have been modified in this update, which maintains the overall integrity of the environment setup while addressing the specific concern.

Closes #2768