### PR TITLE
Revert tokenizers library version from 0.30.0 to 0.29.0 for compatibility and stability while maintaining other library versions. Ensure ongoing monitoring and testing for optimal performance and functionality.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.30.0  # Changed version from 0.29.0 to 0.30.0
+tokenizers==0.29.0  # Changed version from 0.30.0 to 0.29.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2780.
    In this update, the version of the `tokenizers` library has been reverted from `0.30.0` back to `0.29.0`. This change may be due to compatibility issues encountered with the newer version or specific functionality that is required from `0.29.0` that is not present in `0.30.0`. 

All other libraries remain unchanged, maintaining their current versions as specified. This ensures stability while addressing potential problems that could arise with the latest version of `tokenizers`. The decision to revert the version indicates a careful consideration of dependencies and their impact on the overall project functionality. 

As we continue to develop and maintain the codebase, it is crucial to monitor the performance and compatibility of these libraries, especially those that are frequently updated. Keeping track of such changes allows for a more robust application and can prevent unforeseen issues during development and production deployment. 

This version adjustment reflects our ongoing commitment to code quality and functionality, ensuring that all components work harmoniously together. Further testing and validation will be necessary to confirm that reverting to `0.29.0` resolves any issues that prompted this change.

Closes #2780