### PR TITLE
Downgrade tokenizers package from version 0.30.0 to 0.29.0 for compatibility and stability; all other packages remain unchanged. Ensure thorough testing and update documentation accordingly.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.30.0  # Changed version from 0.29.0 to 0.30.0
+tokenizers==0.29.0  # Changed version from 0.30.0 to 0.29.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2792.
    Significant changes in this update include the downgrade of the `tokenizers` package from version 0.30.0 back to 0.29.0. This change might be necessary due to compatibility issues observed in the newer version or specific feature requirements that align better with version 0.29.0. The dependencies in deep learning projects are often tightly coupled, so reverting to a previous version can help maintain stability and ensure that other components function as expected.

All other packages in the list remain unchanged, maintaining their respective versions to ensure the environment's consistency and reliability for development and deployment. The decision to revert the `tokenizers` version should be accompanied by thorough testing to validate that the rest of the codebase continues to operate correctly with this change. 

It is crucial to monitor any issues that arise with the new version of `tokenizers` and gather feedback from the development team to ascertain whether any features or optimizations introduced in version 0.30.0 are necessary for future iterations of the project. Keeping track of such changes can help in planning future updates and maintaining an efficient workflow. 

Please ensure that any associated documentation and user guides reflect this change to avoid confusion among team members and users of the package.

Closes #2792