### PR TITLE
Update tokenizers version from 0.30.0 to 0.29.0 to address compatibility issues and ensure stability in NLP tasks, while keeping other dependencies unchanged for reliability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.30.0  # Changed version from 0.29.0 to 0.30.0
+tokenizers==0.29.0  # Changed version from 0.30.0 to 0.29.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2806.
    This pull request updates the requirements for the project by reverting the version of the `tokenizers` package. The previous version specified was `0.30.0`, which has now been changed back to `0.29.0`. 

The decision to revert the version may be driven by compatibility issues, bugs, or performance regressions observed in `tokenizers` version `0.30.0`. Using `0.29.0` ensures stability and maintains the functionality that relies on this library, particularly in tokenization processes which are critical for model input preparation in NLP tasks.

The remaining dependencies, including core libraries such as `torch`, `torchvision`, and `transformers`, remain unchanged, ensuring that the overall environment continues to function as expected without introducing new variables that could affect the stability of the project.

By retaining the other dependencies at their specified versions, this update minimizes the risk of introducing new issues while addressing the specific concern with the `tokenizers` library. The change reflects a careful consideration of the project's dependency management, which is crucial for maintaining a reliable and reproducible environment for development and deployment.

In summary, the key change in this update is the adjustment of the `tokenizers` version from `0.30.0` back to `0.29.0`, aimed at enhancing the robustness of the codebase.

Closes #2806