### PR TITLE
Revert tokenizers package from version 0.30.0 to 0.29.0 to ensure compatibility and stability across dependencies, addressing user feedback and potential bugs.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.30.0  # Changed version from 0.29.0 to 0.30.0
+tokenizers==0.29.0  # Changed version from 0.30.0 to 0.29.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2812.
    In this update, the primary change involves the `tokenizers` package, which has been reverted from version `0.30.0` back to `0.29.0`. This modification may have been made to address potential compatibility issues or bugs that arose with the newer version, ensuring stability in the overall environment.

The remaining dependencies remain unchanged, maintaining their specified versions to ensure that the project retains its functionality across various components. By reverting `tokenizers` to `0.29.0`, we aim to mitigate any risks introduced by version `0.30.0`, which might not have been fully compatible with other libraries in the stack. 

The decision to make this change likely stems from user feedback or issues encountered during development, highlighting the importance of maintaining a stable and reliable codebase, especially in a widely-used project. This adjustment reflects our commitment to providing a seamless experience for developers and users alike.

Closes #2812