### PR TITLE
Revert tokenizers version from 0.30.0 to 0.29.0 for compatibility and stability with dependent libraries while keeping other dependencies unchanged.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.30.0  # Changed version from 0.29.0 to 0.30.0
+tokenizers==0.29.0  # Changed version from 0.30.0 to 0.29.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2822.
    This pull request includes a significant change in the version of the `tokenizers` library. The version has been reverted from `0.30.0` to `0.29.0`. This adjustment reflects a decision to ensure compatibility with other libraries or specific features that may have been altered or introduced in the later version. 

Reverting to `0.29.0` may address potential issues that users have encountered with `0.30.0`, including functionality or performance regressions. Given the complex ecosystem of dependencies, maintaining a stable environment is crucial, especially when working with libraries that interact closely, such as `transformers` and `datasets`.

It's important to note that the other dependencies remain unchanged in this update. The versions specified for libraries like `torch`, `torchvision`, `torchaudio`, `transformers`, and others continue to align with previously established compatibility requirements. This consistency is vital for ensuring that users can seamlessly integrate the required tools without facing unexpected breaking changes. 

In summary, the primary focus of this update is the alteration of the `tokenizers` version. This change is intended to maintain stability and compatibility within the project's broader dependency landscape, addressing any issues that may have arisen with the newer version while ensuring the overall functionality remains intact.

Closes #2822