### PR TITLE
Revert tokenizers library version from 0.30.0 to 0.29.0 to maintain compatibility and stability due to issues with the newer version. All other dependencies remain unchanged, ensuring integration with existing codebase and functionality.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.30.0  # Changed version from 0.29.0 to 0.30.0
+tokenizers==0.29.0  # Changed version from 0.30.0 to 0.29.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2828.
    This pull request contains a significant change in the version of the `tokenizers` library. Previously, the version was updated from 0.29.0 to 0.30.0, but in this update, it has been reverted back to 0.29.0. 

The decision to revert the version may have been influenced by compatibility issues or breaking changes introduced in the newer version (0.30.0) that affected functionality in the existing codebase. This ensures that the code remains stable and functional with the previously tested and verified version. 

All other dependencies remain unchanged and continue to align with the established compatibility matrix for the project. Keeping the `tokenizers` library at version 0.29.0 allows for smoother integration with other libraries, especially in contexts where specific features or behaviors of the tokenization process are required.

Overall, this update focuses solely on maintaining compatibility and stability for users relying on the previous version of the `tokenizers` library.

Closes #2828