### PR TITLE
Rollback tokenizers package version from 0.31.0 to 0.30.0 to ensure compatibility and address potential issues with other libraries while keeping all other dependencies unchanged. This decision prioritizes stability and reliability in the project’s development environment.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.30
 sentencepiece==0.2.2
-tokenizers==0.31.0  # Changed version from 0.30.0 to 0.31.0
+tokenizers==0.30.0  # Changed version from 0.31.0 to 0.30.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.6.1


### PR DESCRIPTION
This pull request is linked to issue #2858.
    In this update, the primary change made to the code is the modification of the `tokenizers` package version. Specifically, the version was rolled back from `0.31.0` to `0.30.0`. This adjustment was likely made to ensure compatibility with other libraries or to address potential issues introduced in the newer version.

It's important to note that version changes can have significant implications for the stability and functionality of the software. The rollback might indicate that the newer version of `tokenizers` introduced breaking changes or bugs that affected the overall performance or integration with the other libraries in the project. 

This type of revision is not uncommon in projects that rely on a variety of dependencies, especially when working with machine learning frameworks and libraries like `transformers`, `datasets`, and others included in this list. Each of these libraries may have specific requirements or dependencies that need to align correctly for optimal performance.

Additionally, the rest of the dependencies remain unchanged, which suggests that the project is still relying on the same versions of other critical libraries such as `torch`, `torchvision`, `torchaudio`, and `transformers`. Keeping these versions consistent can help maintain a stable development environment and minimize disruptions that may arise from unexpected updates in the ecosystem.

In summary, the change is focused solely on reverting the `tokenizers` version, which reflects a strategic decision to prioritize compatibility and reliability within the project’s dependency management.

Closes #2858