### PR TITLE
Downgrade transformers library from version 4.32.0 to 4.31.0 for compatibility and stability, ensuring no other dependencies are affected and maintaining project functionality. Further testing needed to monitor impacts of this change.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ plaintext
 torch==2.1.0
 torchvision==0.16.0
 torchaudio==0.15.0
-transformers==4.32.0
+transformers==4.31.0
 datasets==2.22.0
 accelerate==0.11.9
 deepspeed==0.17.0


### PR DESCRIPTION
This pull request is linked to issue #2978.
    In this update, we have made a significant change to the version of the `transformers` library. The version has been downgraded from `4.32.0` to `4.31.0`. This change may reflect a need for compatibility with other libraries or a resolution of issues that were present in the newer version. 

All other dependencies remain unchanged, indicating that the focus of this update is strictly on the `transformers` package. By reverting to a previous version, we may aim to ensure stability within the application, especially if there were breaking changes or bugs introduced in the latest release. 

Maintaining compatibility with the entire ecosystem of libraries is crucial for the overall functionality and stability of the project. Given that dependencies can sometimes have conflicting requirements, this change is likely a strategic decision to enhance compatibility and performance in the current setup. 

It's important to monitor the impact of this downgrade on the project's functionality, especially concerning any features or improvements that were introduced in `transformers` version `4.32.0`. Further testing may be required to ensure that all aspects of the project continue to work as expected with this version change. 

No other dependencies have been modified, suggesting that the rest of the project's environment remains stable and consistent with previous setups, which may also contribute to a smoother development and deployment process.

Closes #2978