### PR TITLE
Downgrade transformers library from 4.31.0 to 4.30.0 for compatibility and stability; all other dependencies remain unchanged to ensure stable environment and functionality for users relying on transformers for NLP tasks.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ plaintext
 torch==2.1.0
 torchvision==0.16.0
 torchaudio==0.15.0
-transformers==4.31.0
+transformers==4.30.0
 datasets==2.22.0
 accelerate==0.11.9
 deepspeed==0.17.0


### PR DESCRIPTION
This pull request is linked to issue #2980.
    In this update, the primary change is the version downgrade of the `transformers` library from `4.31.0` to `4.30.0`. This adjustment may have been necessary due to compatibility issues or specific feature requirements that were not met in the newer version. 

The rest of the dependencies remain unchanged, indicating that the core functionality provided by these libraries is stable and does not require updates at this time. Notably, libraries such as `torch`, `torchvision`, `torchaudio`, `datasets`, `accelerate`, `deepspeed`, `peft`, `trl`, `bitsandbytes`, `flash-attn`, `xformers`, `sentencepiece`, `tokenizers`, `tqdm`, `PyYAML`, and `safetensors` continue to maintain their current versions, suggesting that the project is not immediately affected by their newer iterations.

This change is particularly relevant for users who rely on the `transformers` library for natural language processing tasks, as it ensures that any features, APIs, or dependencies introduced in version `4.31.0` do not disrupt existing functionalities. Additionally, keeping the other libraries at their current versions helps maintain a stable environment, particularly for those who may have specific performance or feature needs tied to those versions. 

Overall, the main focus of this update is the compatibility and stability surrounding the `transformers` library, ensuring that ongoing development and deployment processes remain smooth.

Closes #2980