### PR TITLE
Downgrade tokenizers library from 0.50.0 to 0.13.0 for improved stability and compatibility, ensuring existing functionality performs optimally without introducing new dependencies or potential conflicts. No new features added, focusing on maintenance and reliability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.50.0  # Changed version
+tokenizers==0.13.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3038.
    In this update, the primary change involves the version of the `tokenizers` library. Previously, it was specified as version `0.50.0`, and has now been downgraded to `0.13.0`. This change may reflect compatibility adjustments with other libraries or enhancements in functionality that necessitated a shift to an earlier version.

While the impact of this specific version change can vary, it is notable that downgrading to an earlier version may help ensure stability, especially in environments where newer versions introduce breaking changes or bugs that disrupt existing workflows.

All other package versions remain unchanged, indicating a focus on maintaining compatibility across the rest of the dependencies. This stability is crucial for developers relying on the ecosystem for consistent behavior in their applications or research.

It is also worth mentioning that this update does not include any new features or additional packages, which suggests a maintenance-focused release aimed at ensuring that the existing functionality performs optimally without introducing new dependencies or potential conflicts.

The decision to adjust the `tokenizers` version signifies an awareness of the importance of dependency management in the context of machine learning libraries, where intricate relationships between packages can lead to challenges. By opting for a known stable version, the maintainers aim to minimize the risk of issues arising from untested or unstable updates.

This change may also indicate that further testing or user feedback has guided the choice to revert to an older version, highlighting the ongoing commitment of the developers to provide a reliable toolkit for users.

In summary, the most significant change in this update is the downgrade of the `tokenizers` library from `0.50.0` to `0.13.0`, reflecting a careful consideration of compatibility and stability within the project's dependencies. The decision aligns with best practices in software development, particularly in complex systems where dependencies can significantly impact functionality.

Closes #3038