### PR TITLE
Downgrade tokenizers library from 0.15.0 to 0.14.0 for compatibility and stability, ensuring project performance without potential regressions. Other dependencies remain unchanged to maintain expected behavior.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.15.0  # Changed version
+tokenizers==0.14.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3048.
    In this update, the primary change involves the version of the `tokenizers` library. The version has been downgraded from `0.15.0` to `0.14.0`. This adjustment may reflect a need for compatibility with other libraries in the project or a response to specific bugs or issues identified in the newer version. 

The downgrade could be aimed at ensuring stable performance and maintaining functionality without introducing potential regressions that might have come with the latest release. In machine learning workflows, especially those involving numerous dependencies, it's crucial to have control over library versions to mitigate issues stemming from breaking changes or deprecated features. 

Other dependencies remain unchanged, indicating that the core framework of the project still aligns with the established environment setup. This can help ensure that the project retains its expected behavior and performance while minimizing the risk associated with upgrading multiple libraries simultaneously.

Closes #3048