### PR TITLE
Downgrade tokenizers package from version 0.15.0 to 0.14.0 for stability and compatibility with transformers 4.35.0. Ensure performance and integration are not impacted by this change. All other dependencies remain unchanged for consistency and reproducibility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.15.0  # Changed version
+tokenizers==0.14.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3062.
    This update includes a significant change to the `tokenizers` package version. Previously, the version was `0.15.0`, which has now been downgraded to `0.14.0`. This change is noteworthy as it may impact the performance and compatibility of tokenization processes in our workflow, particularly in conjunction with the `transformers` library version `4.35.0`.

The decision to revert to `tokenizers==0.14.0` was likely driven by the need for stability and compatibility with existing models and training scripts. The newer `0.15.0` version may have introduced breaking changes or regressions that affected our implementations, necessitating this downgrade to ensure that the tokenization process functions as expected. 

All other dependencies remain unchanged in this update, indicating that the core libraries and their respective versions are stable and compatible with our project requirements. Keeping these versions consistent is crucial for maintaining reproducibility in experiments and deployments.

It's crucial to monitor any potential impacts this change may have on the overall system, especially in performance benchmarks and integration with other components of the codebase. Furthermore, testing should be conducted to verify that the downgrade does not introduce any unforeseen issues or limitations in functionality. 

Overall, this change reflects our commitment to maintaining a robust and reliable codebase while adapting to the evolving landscape of machine learning libraries.

Closes #3062