### PR TITLE
Downgrade tokenizers from 0.14.0 to 0.13.0 for compatibility with transformers and to enhance codebase stability. No other dependencies modified.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.14.0  # Changed version
+tokenizers==0.13.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3064.
    In this update, the version of the `tokenizers` library has been changed from `0.14.0` to `0.13.0`. This modification may have implications on compatibility with other libraries, particularly `transformers`, which often relies on specific versions of `tokenizers` for efficient tokenization processes. The downgrade might address issues related to breaking changes introduced in version `0.14.0`, ensuring stability and alignment with the other components of the ecosystem.

No other dependencies in the list have been modified, indicating that the focus of this update is solely on the `tokenizers` library. By reverting to an earlier version, we might preserve functionality that could have been disrupted by changes in the newer release, thus enhancing the reliability of the codebase. 

Maintaining compatibility across libraries is crucial, especially in projects that rely heavily on NLP and deep learning frameworks. The decision to change the version of `tokenizers` suggests a careful consideration of the dependencies' interactions and stability.

Closes #3064