### PR TITLE
Downgrade tokenizers library from 0.15.0 to 0.14.0 for improved compatibility and stability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.15.0  # Changed version
+tokenizers==0.14.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3084.
    In this update, the version of the `tokenizers` library has been changed from `0.15.0` to `0.14.0`. This adjustment may be aimed at improving compatibility with other libraries or addressing specific issues related to functionality or performance.

It's worth noting that the `tokenizers` library is essential for efficient tokenization processes in NLP tasks, and changes in its version can affect how text is processed and interpreted by models. The downgrade from `0.15.0` to `0.14.0` could suggest that the newer version may have introduced breaking changes, bugs, or performance regressions that necessitated reverting to a more stable or compatible release.

No other dependencies have been modified in this update, maintaining the overall environment consistent with previous configurations. This change should be monitored for any impacts on the functionality of dependent libraries and the overall performance of the project.

Closes #3084