### PR TITLE
Downgrade tokenizers library from 0.15.0 to 0.14.0 for stability and compatibility with other dependencies. Ensure functionality through comprehensive testing after the change. No other dependencies were altered.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.15.0  # Changed version
+tokenizers==0.14.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3092.
    This update includes a significant change to the version of the `tokenizers` library. The previous version specified was `0.15.0`, which has now been downgraded to `0.14.0`. 

The rationale behind this version change may be attributed to compatibility issues, performance regressions, or bugs introduced in the newer version. By reverting to `0.14.0`, we aim to ensure stability and maintain compatibility with other dependencies within the project. 

It’s important to closely monitor the functionality provided by the `tokenizers` library, as it plays a crucial role in the preprocessing of text data for various NLP tasks. We recommend running comprehensive tests to verify that all functionalities associated with tokenization are working as expected after this change.

No other dependencies have been altered in this update, which suggests that the remaining libraries are either stable or don't require immediate attention for version updates. The focus remains on maintaining compatibility with existing code and ensuring that the overall performance of the project is not adversely affected by changes in library versions. 

As always, we encourage contributors to review the release notes of the affected libraries to stay informed about any potential implications of this version change.

Closes #3092