### PR TITLE
Update tokenizers version from 0.15.0 to 0.14.0 for better compatibility and stability. No other package versions changed, ensuring reliability in the project environment.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.15.0  # Changed version
+tokenizers==0.14.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3098.
    In this update, the primary modification is the version change of the `tokenizers` library from `0.15.0` to `0.14.0`. This change may reflect a decision to stabilize the environment by reverting to a previously stable version known for compatibility with other packages in the ecosystem. 

Using `tokenizers==0.14.0` could help avoid potential issues that may have been introduced in version `0.15.0`, such as bugs or breaking changes that affect the integration with libraries like `transformers` or `datasets`. By ensuring that all dependencies are compatible, we improve the reliability and performance of the project.

No other package versions have been modified in this update, maintaining the existing compatibility across the rest of the dependencies. This careful management of the package versions ensures that developers can continue to build and run applications without encountering unexpected issues due to library updates. 

It is crucial to monitor changes in dependency versions, as even minor updates can lead to significant impacts on functionality. This change is part of our ongoing efforts to maintain a stable and efficient development environment, thereby supporting the project's long-term success and usability for the community.

Closes #3098