### PR TITLE
Downgrade tokenizers package from 0.14.0 to 0.13.3 to address compatibility issues and bugs, ensuring better integration with other libraries while keeping all other dependencies unchanged for stability and performance.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.14.0  # Changed version
+tokenizers==0.13.3  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3102.
    In this update, the primary change is the modification of the `tokenizers` package version from `0.14.0` to `0.13.3`. This downgrade may address compatibility issues or bugs that have arisen with the newer version, ensuring better integration with the other libraries in the environment. 

The remaining dependencies, including `torch`, `torchvision`, `torchaudio`, `transformers`, `datasets`, `accelerate`, `deepspeed`, `peft`, `trl`, `bitsandbytes`, `flash-attn`, `xformers`, `sentencepiece`, `tqdm`, `PyYAML`, and `safetensors`, remain unchanged in their respective versions. This indicates a focus on maintaining stability in the overall environment while resolving potential issues with the `tokenizers` library.

The rationale for this specific version change can be to ensure that the codebase operates reliably with the `transformers` library, which heavily relies on tokenization processes. By reverting to `0.13.3`, we may achieve improved performance or stability, particularly if previous issues with `0.14.0` have been documented by users in the community.

This modification aims to keep the dependencies aligned with best practices and known stable configurations, which is crucial for projects that prioritize performance and reliability, especially in large-scale applications or research settings where dependability is paramount. 

Overall, the focus remains on maintaining a robust and functional environment, with careful consideration given to the compatibility and performance implications of each library version.

Closes #3102