### PR TITLE
Downgrade tokenizers library from 0.14.0 to 0.13.3 for compatibility and stability, ensuring existing functionality remains intact. No other dependencies modified. Monitor integration and run tests to validate functionality and prevent regressions. Prioritize stability while keeping an eye on future updates.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.14.0  # Changed version
+tokenizers==0.13.3  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3106.
    This pull request includes a significant update to the `tokenizers` library version, changing it from `0.14.0` to `0.13.3`. This downgrade could be due to compatibility issues identified in the latest version or to maintain stability across the project, ensuring that existing functionality remains intact. 

The impact of this change may include alterations in performance, bug fixes, or feature sets that were introduced or deprecated in the newer version of `tokenizers`. By opting for `0.13.3`, we are prioritizing the stability and reliability of our dependencies, especially given the critical role tokenization plays in natural language processing tasks.

No other dependencies were modified in this pull request, meaning that the underlying architecture and functionalities provided by the other libraries remain unchanged. This ensures that any improvements or features from those libraries continue to be leveraged without interference from the tokenizers update.

It is crucial to monitor the integration of this version in our environment, testing for any discrepancies that may arise due to the change in the tokenizers version. We recommend running a comprehensive set of tests to validate that the functionality remains as expected and that no regressions are introduced as a result of this adjustment.

The choice to revert the tokenizers version also reflects a careful approach to dependency management, which is essential in maintaining the health of a project with high usage and visibility in the community. By ensuring compatibility and stability, we enhance the overall user experience and reliability of the project.

As we proceed with this change, we will continue to keep an eye on future releases of the `tokenizers` library for improvements that may warrant another upgrade, while balancing the need for stability in our current development cycle.

Closes #3106