### PR TITLE
Downgrade tokenizers library from 0.14.0 to 0.13.3 for compatibility and stability in the development environment, ensuring existing features function without introducing bugs or performance issues. No other libraries modified, maintaining dependency integrity.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.14.0  # Changed version
+tokenizers==0.13.3  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3118.
    Significant changes in the updated code include the version change for the `tokenizers` library, which has been downgraded from `0.14.0` to `0.13.3`. This adjustment may be necessary due to compatibility issues with other libraries or specific functionalities that were altered in the newer version. The decision to revert to an earlier version suggests a need for stability in the development environment, ensuring that existing features continue to function as intended without introducing potential bugs or performance regressions that might accompany the latest updates.

No other libraries have been modified, maintaining the integrity of the existing dependencies. The versioning consistency across the remaining packages indicates careful consideration of compatibility and performance within the project's ecosystem.

Closes #3118