### PR TITLE
Downgrade tokenizers library from version 0.14.0 to 0.13.3 for stability and compatibility with existing dependencies while ensuring reliable functionality in the project. No other dependencies changed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.14.0  # Changed version
+tokenizers==0.13.3  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3126.
    In this update, we have made a significant change to the `tokenizers` library version. The previous version specified was `0.14.0`, which has now been downgraded to `0.13.3`. This adjustment may have been made to ensure compatibility with other libraries in the project or to address specific issues encountered with the later version.

The rationale behind choosing `0.13.3` could stem from the need to maintain stability within the codebase, especially if the new features or changes in `0.14.0` introduced regressions or incompatibilities with the current implementations. By reverting to `0.13.3`, we are prioritizing a reliable development environment that aligns well with the existing dependencies.

It is essential to monitor the implications of this version change on the overall functionality of the project, particularly in areas where the `tokenizers` library is heavily utilized. This may involve revisiting any related code to ensure that it operates as expected under the older version of the library.

All other dependencies remain unchanged, indicating that we are not introducing any new features or altering the functionality of other components at this time. This focused update on the `tokenizers` version reflects a careful consideration of stability over adopting the latest version, which is a common practice in software development, particularly in large-scale projects with substantial community reliance. 

As we move forward, it will be crucial to keep track of any new releases from the `tokenizers` library and evaluate their potential benefits against the stability and performance requirements of our project. This approach will help ensure that we can incorporate improvements in future updates while maintaining seamless operation for our users.

Closes #3126