### PR TITLE
Update tokenizers library from 0.15.0 to 0.14.0 for compatibility and performance adjustments, while keeping other library versions unchanged to maintain stability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.15.0  # Changed version
+tokenizers==0.14.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3142.
    This update includes a significant change to the version of the `tokenizers` library, which has been downgraded from `0.15.0` to `0.14.0`. This adjustment may have implications for compatibility and performance based on the features and bug fixes introduced or removed in these versions. Users should review the changelog for both versions to understand any potential impacts this change may have on their projects.

All other library versions remain unchanged, indicating a focus on maintaining stability in those dependencies while addressing the specific needs related to the `tokenizers` library.

Closes #3142