### PR TITLE
Downgrade tokenizers library from 0.21.0 to 0.20.0 for compatibility with other libraries and to maintain stability in the codebase. No other library versions were changed.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.21.0  # Changed version
+tokenizers==0.20.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3196.
    In this update, the primary change is the version of the `tokenizers` library. The version has been downgraded from `0.21.0` to `0.20.0`. This adjustment may reflect compatibility considerations with other libraries in the environment or specific functionality that is required for the project.

It's essential to note that downgrading a library version can impact performance or feature availability. In this case, the `tokenizers` library is a crucial component for handling tokenization tasks in NLP applications, and ensuring it aligns with the versions of other libraries (such as `transformers` and `datasets`) is critical for maintaining stability in the codebase.

No other library versions have been altered in this commit, indicating a focus on ensuring that the dependencies are appropriately aligned without introducing further changes that could complicate dependency management. The selected versions of other packages, such as `torch`, `torchvision`, `torchaudio`, and others, have been retained, suggesting confidence in their stability and functionality for the current project requirements.

Overall, this change seems to prioritize ensuring compatibility and reliability within the existing framework while adhering to the best practices of managing library dependencies in Python projects, especially in complex machine learning and data processing environments.

Closes #3196