### PR TITLE
Downgrade tokenizers library from 0.21.0 to 0.20.0 for compatibility and stability, while keeping other dependencies unchanged to maintain project integrity and minimize risks.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.21.0  # Changed version
+tokenizers==0.20.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3200.
    Significant changes in the updated code include the version downgrade of the `tokenizers` library from `0.21.0` to `0.20.0`. This change may have been implemented to address compatibility issues or to ensure stability with other dependencies in the project. The choice of version `0.20.0` could reflect a need for a feature set or bug fixes present in that specific release which are not available in `0.21.0`.

The rest of the dependencies remain unchanged, indicating a focused effort to maintain the integrity of the environment while resolving concerns specifically around the `tokenizers` library. By keeping the remaining libraries at their previous versions, the project aims to minimize the risk of introducing new issues that often accompany updates of multiple dependencies. 

Overall, this targeted update illustrates a cautious approach to dependency management, prioritizing stability and compatibility within the project ecosystem.

Closes #3200