### PR TITLE
Downgrade tokenizers package from version 0.21.0 to 0.20.0 to ensure compatibility and functionality, while keeping all other dependencies unchanged. Testing required to verify project stability after this change.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.21.0  # Changed version
+tokenizers==0.20.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3208.
    This update includes a significant change to the `tokenizers` package, which has been downgraded from version `0.21.0` to `0.20.0`. This alteration may impact the compatibility and functionality of tokenization processes within the project. The specific reasons for this version change should be further investigated, as there may be bug fixes, performance improvements, or potential issues with the newer version that necessitated this adjustment.

All other dependencies remain unchanged in this update, maintaining their respective versions as listed in the previous code. It is crucial to ensure that all components of the project continue to work seamlessly together following this change. Testing should be conducted to verify that functionalities dependent on the `tokenizers` library behave as expected with this new version.

Additionally, it might be beneficial to review the release notes or changelogs for the `tokenizers` library between versions `0.20.0` and `0.21.0` to fully understand any modifications that could affect the project. This can help in diagnosing any issues that arise and in making informed decisions about future updates.

The rest of the libraries, including `torch`, `torchvision`, `torchaudio`, `transformers`, `datasets`, `accelerate`, `deepspeed`, `peft`, `trl`, `bitsandbytes`, `flash-attn`, `xformers`, `sentencepiece`, `tqdm`, `PyYAML`, and `safetensors`, remain at their previously specified versions, indicating stability in those areas of the codebase. 

Overall, the primary focus of this update is the adjustment to the `tokenizers` version, and it is imperative to ensure compatibility across the entire stack to prevent any unforeseen issues in the project’s performance or functionality.

Closes #3208