### PR TITLE
Downgrade tokenizers library from 0.21.0 to 0.20.0 for better compatibility and stability, addressing potential issues without modifying other dependencies.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.21.0  # Changed version
+tokenizers==0.20.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3224.
    In this update, the main significant change is the version of the `tokenizers` library, which has been downgraded from `0.21.0` to `0.20.0`. This change may address compatibility issues or bugs that were present in the newer version. 

The `tokenizers` library is crucial for tokenization tasks in NLP (Natural Language Processing) pipelines, and ensuring its stability can be vital for the performance of models that rely on it. Downgrading to a previous version may provide better integration with other libraries in the stack, particularly with the `transformers` library, which is tightly coupled with tokenization processes.

No other dependencies have been modified in this update, which suggests that the focus was specifically on the `tokenizers` version to maintain stability or compatibility with existing code and models. This careful adjustment reflects a commitment to ensuring that the entire environment remains functional and efficient for users, especially given the complexity and interdependencies of modern machine learning frameworks. 

By keeping other libraries at their current versions, this update minimizes the risk of introducing new issues while addressing potential problems with `tokenizers`. Overall, this strategic change should enhance the reliability of the overall package without compromising the functionality provided by other dependencies.

Closes #3224