### PR TITLE
Downgrade tokenizers library from 0.21.0 to 0.20.0 for compatibility and stability, while retaining other library versions. Monitor impact on project functionality and document changes in release notes for clarity. Focused approach to maintain reliability without unnecessary complexities.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.21.0  # Changed version
+tokenizers==0.20.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3234.
    In this update, the primary change is the version of the `tokenizers` library, which has been downgraded from version 0.21.0 to 0.20.0. This change may have been made to address compatibility issues with other libraries or to ensure stability in the project's dependencies. 

The remaining libraries retain their previous versions, indicating that no other dependencies were modified in this update. This decision suggests that the other libraries are functioning as expected and do not require immediate changes. 

It's essential to monitor the impact of this downgrade on the overall functionality of the project, especially if there are features or performance enhancements in the newer version of `tokenizers` that were beneficial. 

Additionally, this change aligns the project more closely with earlier tested configurations, which may help in resolving any outstanding issues that have arisen from the recent updates to the tokenizers library. 

No other modifications were made to the dependencies, indicating a focused approach to maintaining stability while addressing specific concerns related to the `tokenizers` library. 

The decision to revert the `tokenizers` version should be documented in the project's release notes or changelog to inform contributors and users about the rationale behind this adjustment. 

Overall, this update reflects a careful consideration of package versions to ensure the reliability and performance of the project without introducing unnecessary complexities or potential regressions from other libraries.

Closes #3234