### PR TITLE
Revert tokenizers version from 0.21.0 to 0.20.0 for stability and compatibility, ensuring a reliable environment and minimizing potential issues with dependency conflicts in the project.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
 sentencepiece==0.2.2
-tokenizers==0.21.0  # Changed version
+tokenizers==0.20.0  # Changed version
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0


### PR DESCRIPTION
This pull request is linked to issue #3268.
    In this update, we see a significant change regarding the `tokenizers` library. The version has been modified from `0.21.0` to `0.20.0`. This adjustment may reflect a decision to stabilize the dependencies, possibly addressing compatibility issues or bugs present in the newer version. Such changes are crucial in maintaining a reliable environment, especially when working with libraries that are often updated and can introduce breaking changes.

Beyond the version adjustment of `tokenizers`, the rest of the dependencies remain unchanged. The choice to revert to an earlier version of `tokenizers` suggests that the team has prioritized stability and compatibility over the latest features or improvements that may come with the newer version. It's essential in large projects to ensure that all components work harmoniously, and sometimes this means stepping back to a version that is known to function correctly within the existing ecosystem.

Overall, this change should lead to a more robust and stable setup for developers and users of the project, minimizing the risk of encountering issues related to dependency conflicts or unexpected behavior from new versions of the libraries.

Closes #3268