### PR TITLE
Removed duplicate entry for trl==0.13.0, retained trl==0.14.0, no other dependencies modified, ensuring consistency and compatibility.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ datasets==2.22.0
 accelerate==0.11.9
 deepspeed==0.17.0
 peft==0.15.0
-trl==0.13.0
+trl==0.14.0
 bitsandbytes==0.46.0
 flash-attn==2.8.0
 xformers==0.0.31
@@ -16,4 +16,3 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.14.0


### PR DESCRIPTION
This pull request is linked to issue #3293.
    The main significant changes in the updated code are as follows:

1. Removed duplicate entry for `trl==0.13.0`: The original code had two entries for `trl`, one with version `0.13.0` and another with `0.14.0`. The updated code retains only `trl==0.14.0`, ensuring consistency and avoiding potential conflicts.

2. No other dependencies were modified: All other package versions remain unchanged, ensuring that the core functionality and compatibility of the project are preserved. This includes maintaining the same versions for `torch`, `torchvision`, `torchaudio`, `transformers`, `datasets`, `accelerate`, `deepspeed`, `peft`, `bitsandbytes`, `flash-attn`, `xformers`, `sentencepiece`, `tokenizers`, `tqdm`, `PyYAML`, and `safetensors`.

These changes streamline the dependency list and ensure that the project uses the latest version of `trl` without introducing any breaking changes or inconsistencies.

Closes #3293