### PR TITLE
Update CLI help text for better clarity and consistency without changing functional logic

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -37,13 +37,13 @@ def find_impacted_tests(project_dir, changed_funcs):
     } for test in tests for call in test["method_calls"] if call in changed_funcs]
 
 @click.command()
-@click.option('--repo', required=True, help='Location of the repository')
-@click.option('--commit_id', required=True, help='Hash of the commit to inspect')
-@click.option('--project_path', required=True, help='Directory of the project')
+@click.option('--repo', required=True, help='Path to the repository')
+@click.option('--commit_id', required=True, help='Commit hash to analyze')
+@click.option('--project_path', required=True, help='Path to the project directory')
 def cli(repo, commit_id, project_path):
     changed_funcs = get_changed_functions(repo, commit_id)
     if not changed_funcs:
-        click.echo("No function modifications found.")
+        click.echo("No changes detected in functions.")
         return
     click.echo(json.dumps(find_impacted_tests(project_path, changed_funcs), indent=2))
 


### PR DESCRIPTION
This pull request is linked to issue #3379.
    The main changes in this code are minimal and primarily involve updates to the CLI help text for better clarity and consistency. The functional logic remains unchanged, ensuring no impact on the behavior of the script. Here are the specific updates:

1. The help text for the `--repo` option has been updated from "Location of the repository" to "Path to the repository" to align with the terminology used for other options.
2. The help text for the `--commit_id` option has been updated from "Hash of the commit to inspect" to "Commit hash to analyze" for consistency and clarity.
3. The help text for the `--project_path` option has been updated from "Directory of the project" to "Path to the project directory" to maintain a consistent format with the other options.
4. The message when no function modifications are found has been updated from "No function modifications found." to "No changes detected in functions." for improved readability and user feedback.

These changes are purely cosmetic and do not affect the core functionality of the script. The updates aim to improve the user experience by providing clearer and more consistent descriptions for the CLI options and output messages.

Closes #3379