### PR TITLE
PR: Rename variables and functions for clarity and consistency, refactor code for readability, and rename CLI function to main

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -5,47 +5,47 @@ import click
 from parso import parse
 from parso.python.tree import Function
 
-PY_LANGUAGE = "python"
+PYTHON_LANG = "python"
 
-def get_changed_functions(repo_path, commit_hash):
-    os.chdir(repo_path)
-    diff = subprocess.check_output(["git", "diff", commit_hash, "--", "*.py"], text=True)
-    return {parts[3].split('(')[0].strip('+') for line in diff.split('\n') 
-            if line.startswith('@@') and len(parts := line.split()) > 3 and '(' in parts[3]}
+def fetch_modified_functions(repo_dir, commit_ref):
+    os.chdir(repo_dir)
+    diff_output = subprocess.check_output(["git", "diff", commit_ref, "--", "*.py"], text=True)
+    return {segment[3].split('(')[0].strip('+') for line in diff_output.split('\n') 
+            if line.startswith('@@') and len(segment := line.split()) > 3 and '(' in segment[3]}
 
-def find_test_functions(project_dir):
-    tests = []
-    for root, _, files in os.walk(project_dir):
-        for file in files:
-            if file.endswith(".py"):
-                full_path = os.path.join(root, file)
-                with open(full_path, "r", encoding="utf-8") as f:
-                    module = parse(f.read())
-                tests.extend({
-                    "file": full_path,
-                    "test_name": node.name.value,
-                    "method_calls": [call.value for child in node.children if isinstance(child, Function) for call in child.iter_call_names()]
-                } for node in module.iter_funcdefs() if "test" in node.name.value)
-    return tests
+def locate_test_methods(project_root):
+    test_cases = []
+    for dirpath, _, filenames in os.walk(project_root):
+        for filename in filenames:
+            if filename.endswith(".py"):
+                file_path = os.path.join(dirpath, filename)
+                with open(file_path, "r", encoding="utf-8") as file:
+                    parsed_module = parse(file.read())
+                test_cases.extend({
+                    "file": file_path,
+                    "test_name": func.name.value,
+                    "method_calls": [call.value for child in func.children if isinstance(child, Function) for call in child.iter_call_names()]
+                } for func in parsed_module.iter_funcdefs() if "test" in func.name.value)
+    return test_cases
 
-def find_impacted_tests(project_dir, changed_funcs):
-    tests = find_test_functions(project_dir)
+def identify_affected_tests(project_root, modified_funcs):
+    test_methods = locate_test_methods(project_root)
     return [{
         "file": test["file"],
         "test_name": test["test_name"],
         "called_function": call
-    } for test in tests for call in test["method_calls"] if call in changed_funcs]
+    } for test in test_methods for call in test["method_calls"] if call in modified_funcs]
 
 @click.command()
-@click.option('--repo', required=True, help='Path to the repository')
-@click.option('--commit_id', required=True, help='Commit hash to analyze')
-@click.option('--project_path', required=True, help='Path to the project directory')
-def cli(repo, commit_id, project_path):
-    changed_funcs = get_changed_functions(repo, commit_id)
-    if not changed_funcs:
-        click.echo("No changes detected in functions.")
+@click.option('--repo', required=True, help='Repository directory path')
+@click.option('--commit_id', required=True, help='Commit reference to analyze')
+@click.option('--project_path', required=True, help='Project root directory path')
+def main(repo, commit_id, project_path):
+    modified_funcs = fetch_modified_functions(repo, commit_id)
+    if not modified_funcs:
+        click.echo("No function modifications detected.")
         return
-    click.echo(json.dumps(find_impacted_tests(project_path, changed_funcs), indent=2))
+    click.echo(json.dumps(identify_affected_tests(project_path, modified_funcs), indent=2))
 
 if __name__ == "__main__":
-    cli()
+    main()


### PR DESCRIPTION
This pull request is linked to issue #3387.
    The main significant changes in the updated code are as follows:

1. **Variable and Function Renaming**: 
   - `PY_LANGUAGE` has been renamed to `PYTHON_LANG` for better clarity and consistency.
   - `get_changed_functions` is now `fetch_modified_functions`, `find_test_functions` is now `locate_test_methods`, and `find_impacted_tests` is now `identify_affected_tests`. These changes improve readability and align with more descriptive naming conventions.
   - `repo_path` and `commit_hash` in `get_changed_functions` are now `repo_dir` and `commit_ref` respectively, making the parameter names more intuitive.

2. **Code Refactoring**:
   - The variable `diff` in `get_changed_functions` is now `diff_output`, and `parts` is now `segment`, improving clarity in the context of the code.
   - In `find_test_functions`, the variable `module` is now `parsed_module`, and `node` is now `func`, making the code more readable and contextually accurate.
   - The list `tests` in `find_test_functions` is now `test_cases`, and `tests` in `find_impacted_tests` is now `test_methods`, aligning with the purpose of the variables.

3. **Functionality**:
   - The logic and functionality remain unchanged, ensuring that the code continues to perform the same operations: identifying modified functions from a Git commit and determining which test methods are affected by these changes.

4. **CLI Function**:
   - The `cli` function is now named `main`, which is a more conventional name for the entry point of a script.

These changes primarily focus on improving code readability, maintainability, and consistency without altering the core functionality.

Closes #3387