### PR TITLE
Update `locate_test_methods` to use case-insensitive check for identifying test methods

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -25,7 +25,7 @@ def locate_test_methods(project_root):
                     "file": file_path,
                     "test_name": func.name.value,
                     "method_calls": [call.value for child in func.children if isinstance(child, Function) for call in child.iter_call_names()]
-                } for func in parsed_module.iter_funcdefs() if "test" in func.name.value)
+                } for func in parsed_module.iter_funcdefs() if "test" in func.name.value.lower())
     return test_cases
 
 def identify_affected_tests(project_root, modified_funcs):


### PR DESCRIPTION
This pull request is linked to issue #3394.
    The main significant change in this code is the modification to the `locate_test_methods` function. Specifically, the condition to identify test methods has been updated to be case-insensitive. Previously, the code checked if the function name contained the substring "test" using `if "test" in func.name.value`. This has been changed to `if "test" in func.name.value.lower()`, ensuring that test methods are identified regardless of their casing (e.g., "Test", "TEST", "test").

This change improves the robustness of the code by ensuring that all test methods, regardless of their naming conventions, are correctly identified and included in the analysis. This is particularly important in large projects where naming conventions may vary, and some test methods might not follow the exact lowercase "test" pattern.

No other changes were made to the code, and the functionality remains consistent with the original implementation. This update aligns with best practices for handling case-insensitive string comparisons and ensures broader compatibility with diverse codebases.

Closes #3394