### PR TITLE
Refactor code to use lambda functions and inline expressions for conciseness, potentially reducing readability

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -7,144 +7,130 @@ from sklearn.preprocessing import LabelEncoder
 import matplotlib.pyplot as plt
 from tensorflow.keras import layers, optimizers, losses
 
-def collect_texts(triplet_info):
-    return [text for entry in triplet_info for text in (entry['anchor'], entry['positive'], entry['negative'])]
+gather_texts = lambda triplet_data: [text for item in triplet_data for text in (item['anchor'], item['positive'], item['negative'])]
 
-def encode_sequences(encoder, data_entry):
-    return {
-        'anchor_seq': tf.convert_to_tensor(encoder.transform([data_entry['anchor']])[0]),
-        'positive_seq': tf.convert_to_tensor(encoder.transform([data_entry['positive']])[0]),
-        'negative_seq': tf.convert_to_tensor(encoder.transform([data_entry['negative']])[0])
+tokenize_sequences = lambda tokenizer, data_item: {
+    'anchor_seq': tf.convert_to_tensor(tokenizer.transform([data_item['anchor']])[0]),
+    'positive_seq': tf.convert_to_tensor(tokenizer.transform([data_item['positive']])[0]),
+    'negative_seq': tf.convert_to_tensor(tokenizer.transform([data_item['negative']])[0])
+}
+
+shuffle_data = lambda data_samples: random.shuffle(data_samples) or data_samples
+
+generate_triplets = lambda instance_dict, bug_samples, non_bug_samples: [
+    {
+        'anchor': instance_dict[os.path.basename(folder)],
+        'positive': bug_sample,
+        'negative': random.choice(non_bug_samples)
     }
+    for folder, _ in snippet_files
+    for bug_sample in bug_samples
+]
 
-def randomize_data(data_entries):
-    random.shuffle(data_entries)
-    return data_entries
+load_json_data = lambda file_path, root_dir: (
+    lambda json_content: (
+        {entry['instance_id']: entry['problem_statement'] for entry in json_content},
+        [(folder, os.path.join(root_dir, 'snippet.json')) for folder in os.listdir(root_dir) if os.path.isdir(os.path.join(root_dir, folder))]
+    )
+)(json.load(open(file_path, 'r')))
 
-def create_triplets(instance_map, bug_entries, non_bug_entries):
-    return [
-        {
-            'anchor': instance_map[os.path.basename(dir)],
-            'positive': bug_entry,
-            'negative': random.choice(non_bug_entries)
-        }
-        for dir, _ in snippet_paths
-        for bug_entry in bug_entries
-    ]
-
-def load_json(file_path, base_dir):
-    with open(file_path, 'r') as f:
-        json_data = json.load(f)
-    instance_map = {item['instance_id']: item['problem_statement'] for item in json_data}
-    snippet_paths = [(dir, os.path.join(base_dir, 'snippet.json')) for dir in os.listdir(base_dir) if os.path.isdir(os.path.join(base_dir, dir))]
-    return instance_map, snippet_paths
-
-def prepare_dataset(instance_map, snippet_paths):
-    bug_entries, non_bug_entries = zip(*[json.load(open(path)) for path in snippet_paths])
-    return create_triplets(instance_map, bug_entries, non_bug_entries)
+prepare_triplet_dataset = lambda instance_dict, snippet_files: generate_triplets(instance_dict, *zip(*[json.load(open(path)) for path in snippet_files]))
 
 class TripletData:
-    def __init__(self, triplet_info):
-        self.triplet_info = triplet_info
-        self.encoder = LabelEncoder().fit(collect_texts(triplet_info))
+    def __init__(self, triplet_data):
+        self.triplet_data = triplet_data
+        self.tokenizer = LabelEncoder().fit(gather_texts(triplet_data))
 
-    def get_entries(self):
-        return self.triplet_info
+    get_samples = lambda self: self.triplet_data
 
 class TripletDataset(tf.data.Dataset):
-    def __init__(self, triplet_info):
-        self.data = TripletData(triplet_info)
-        self.entries = self.data.get_entries()
+    def __init__(self, triplet_data):
+        self.data = TripletData(triplet_data)
+        self.samples = self.data.get_samples()
 
-    def __len__(self):
-        return len(self.entries)
-
-    def __getitem__(self, idx):
-        return encode_sequences(self.data.encoder, self.entries[idx])
+    __len__ = lambda self: len(self.samples)
+    __getitem__ = lambda self, index: tokenize_sequences(self.data.tokenizer, self.samples[index])
 
 class TripletModel(tf.keras.Model):
-    def __init__(self, vocab_size, embed_dim):
+    def __init__(self, vocab_size, embedding_dim):
         super(TripletModel, self).__init__()
-        self.embedding = layers.Embedding(vocab_size, embed_dim)
-        self.network = tf.keras.Sequential([
+        self.embedding_layer = layers.Embedding(vocab_size, embedding_dim)
+        self.dense_network = tf.keras.Sequential([
             layers.Dense(128, activation='relu'),
             layers.BatchNormalization(),
             layers.Dropout(0.2),
             layers.Dense(128)
         ])
 
-    def call(self, anchor, positive, negative):
-        anchor_embed = self.network(self.embedding(anchor))
-        positive_embed = self.network(self.embedding(positive))
-        negative_embed = self.network(self.embedding(negative))
-        return anchor_embed, positive_embed, negative_embed
+    call = lambda self, anchor, positive, negative: (
+        self.dense_network(self.embedding_layer(anchor)),
+        self.dense_network(self.embedding_layer(positive)),
+        self.dense_network(self.embedding_layer(negative))
+    )
 
-def compute_loss(anchor_embeds, positive_embeds, negative_embeds):
-    return tf.reduce_mean(tf.maximum(0.2 + tf.norm(anchor_embeds - positive_embeds, axis=1) - tf.norm(anchor_embeds - negative_embeds, axis=1), 0))
+calculate_loss = lambda anchor_embeds, positive_embeds, negative_embeds: tf.reduce_mean(tf.maximum(0.2 + tf.norm(anchor_embeds - positive_embeds, axis=1) - tf.norm(anchor_embeds - negative_embeds, axis=1), 0))
 
-def train(model, train_loader, valid_loader, epochs):
-    optimizer = optimizers.Adam(learning_rate=1e-5)
-    history = []
-    for _ in range(epochs):
-        for batch in train_loader:
-            with tf.GradientTape() as tape:
-                anchor_embeds, positive_embeds, negative_embeds = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-                loss = compute_loss(anchor_embeds, positive_embeds, negative_embeds)
-            gradients = tape.gradient(loss, model.trainable_variables)
-            optimizer.apply_gradients(zip(gradients, model.trainable_variables))
-        history.append((loss.numpy(), *evaluate(model, valid_loader)))
-    return history
+train_model = lambda model, train_loader, valid_loader, epochs: (
+    lambda optimizer, history: [
+        [
+            [
+                (lambda anchor_embeds, positive_embeds, negative_embeds, loss: (
+                    optimizer.apply_gradients(zip(tape.gradient(loss, model.trainable_variables), model.trainable_variables)),
+                    history.append((loss.numpy(), *evaluate_model(model, valid_loader)))
+                )(model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq']), calculate_loss(anchor_embeds, positive_embeds, negative_embeds))
+            ) for batch in train_loader
+        ] for _ in range(epochs)
+    ] or history
+)(optimizers.Adam(learning_rate=1e-5), [])
 
-def evaluate(model, valid_loader):
-    loss, correct = 0, 0
-    for batch in valid_loader:
-        anchor_embeds, positive_embeds, negative_embeds = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-        loss += compute_loss(anchor_embeds, positive_embeds, negative_embeds).numpy()
-        correct += count_correct(anchor_embeds, positive_embeds, negative_embeds)
-    return loss / len(valid_loader), correct / len(valid_loader.dataset)
+evaluate_model = lambda model, valid_loader: (
+    lambda loss, correct: (
+        loss / len(valid_loader), correct / len(valid_loader.dataset))
+    )(
+        sum(calculate_loss(*model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])).numpy() for batch in valid_loader),
+        sum(count_matches(*model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])) for batch in valid_loader)
+    )
 
-def count_correct(anchor_output, positive_output, negative_output):
-    return tf.reduce_sum(tf.cast(tf.reduce_sum(anchor_output * positive_output, axis=1) > tf.reduce_sum(anchor_output * negative_output, axis=1), tf.int32)).numpy()
+count_matches = lambda anchor_output, positive_output, negative_output: tf.reduce_sum(tf.cast(tf.reduce_sum(anchor_output * positive_output, axis=1) > tf.reduce_sum(anchor_output * negative_output, axis=1), tf.int32)).numpy()
 
-def plot_history(history):
-    train_losses, val_losses, train_accuracies = zip(*history)
-    plt.figure(figsize=(10, 5))
-    plt.subplot(1, 2, 1)
-    plt.plot(train_losses, label='Training Loss')
-    plt.plot(val_losses, label='Validation Loss')
-    plt.title('Loss Over Epochs')
-    plt.xlabel('Epochs')
-    plt.ylabel('Loss')
-    plt.legend()
-    plt.subplot(1, 2, 2)
-    plt.plot(train_accuracies, label='Training Accuracy')
-    plt.title('Accuracy Over Epochs')
-    plt.xlabel('Epochs')
-    plt.ylabel('Accuracy')
-    plt.legend()
-    plt.show()
+plot_results = lambda history: (
+    lambda train_losses, val_losses, train_accuracies: (
+        plt.figure(figsize=(10, 5)),
+        plt.subplot(1, 2, 1),
+        plt.plot(train_losses, label='Training Loss'),
+        plt.plot(val_losses, label='Validation Loss'),
+        plt.title('Loss Over Epochs'),
+        plt.xlabel('Epochs'),
+        plt.ylabel('Loss'),
+        plt.legend(),
+        plt.subplot(1, 2, 2),
+        plt.plot(train_accuracies, label='Training Accuracy'),
+        plt.title('Accuracy Over Epochs'),
+        plt.xlabel('Epochs'),
+        plt.ylabel('Accuracy'),
+        plt.legend(),
+        plt.show())
+    )(*zip(*history))
 
-def save_model_weights(model, path):
-    model.save_weights(path)
-    print(f'Model saved at {path}')
+save_model = lambda model, filepath: (model.save_weights(filepath), print(f'Model saved at {filepath}'))
 
-def load_model_weights(model, path):
-    model.load_weights(path)
-    print(f'Model loaded from {path}')
-    return model
+load_model = lambda model, filepath: (model.load_weights(filepath), print(f'Model loaded from {filepath}'), model)
 
-def main():
-    dataset_path = 'datasets/SWE-bench_oracle.npy'
-    snippets_dir = 'datasets/10_10_after_fix_pytest'
-    instance_map, snippet_paths = load_json(dataset_path, snippets_dir)
-    triplet_info = prepare_dataset(instance_map, snippet_paths)
-    train_data, valid_data = np.array_split(np.array(triplet_info), 2)
-    train_loader = tf.data.Dataset.from_tensor_slices(train_data.tolist()).batch(32).shuffle(len(train_data))
-    valid_loader = tf.data.Dataset.from_tensor_slices(valid_data.tolist()).batch(32)
-    model = TripletModel(vocab_size=len(train_loader.dataset.data.encoder.classes_) + 1, embed_dim=128)
-    history = train(model, train_loader, valid_loader, epochs=5)
-    plot_history(history)
-    save_model_weights(model, 'triplet_model.h5')
+main = lambda: (
+    lambda dataset_path, snippets_directory, instance_dict, snippet_paths, triplet_data, train_data, valid_data, train_loader, valid_loader, model, history: (
+        plot_results(history),
+        save_model(model, 'triplet_model.h5'))
+    )(
+        'datasets/SWE-bench_oracle.npy',
+        'datasets/10_10_after_fix_pytest',
+        *load_json_data('datasets/SWE-bench_oracle.npy', 'datasets/10_10_after_fix_pytest')),
+        prepare_triplet_dataset(instance_dict, snippet_paths),
+        *np.array_split(np.array(triplet_data), 2),
+        tf.data.Dataset.from_tensor_slices(train_data.tolist()).batch(32).shuffle(len(train_data)),
+        tf.data.Dataset.from_tensor_slices(valid_data.tolist()).batch(32),
+        TripletModel(vocab_size=len(train_loader.dataset.data.tokenizer.classes_) + 1, embedding_dim=128),
+        train_model(model, train_loader, valid_loader, epochs=5))
+    )
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request is linked to issue #3407.
    The main significant changes in the updated code involve refactoring the code to use lambda functions and inline expressions, making the code more concise but potentially less readable. Here are the key changes:

1. Functions like `gather_texts`, `tokenize_sequences`, `shuffle_data`, `generate_triplets`, `load_json_data`, and `prepare_triplet_dataset` have been converted to lambda functions. This reduces the number of lines but may make the code harder to debug and understand.

2. The `TripletData` class methods `get_samples`, `__len__`, and `__getitem__` in `TripletDataset` have been replaced with lambda functions. This change simplifies the class definition but may obscure the logic for those unfamiliar with lambda usage.

3. The `call` method in `TripletModel` has been replaced with a lambda function, making the model's forward pass more compact but potentially less clear.

4. The `calculate_loss`, `train_model`, `evaluate_model`, `count_matches`, `plot_results`, `save_model`, and `load_model` functions have been refactored into lambda expressions. This reduces verbosity but may make the code harder to follow, especially for complex logic like `train_model`.

5. The `main` function has been rewritten as a lambda function, chaining operations in a single expression. This makes the function more compact but harder to debug and understand.

These changes prioritize conciseness over readability, which may not be ideal for collaborative projects or long-term maintenance. The original code, while more verbose, is generally easier to understand and debug.

Closes #3407