### PR TITLE
Removed docstrings from functions, impacting code readability and maintainability without changing core functionality or structure.

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -8,31 +8,12 @@ from parso.python.tree import Function
 PYTHON = "python"
 
 def get_changed_functions(repo_path, commit_hash):
-    """
-    Retrieves the names of functions that were changed in the specified commit.
-    
-    Args:
-        repo_path (str): Path to the repository.
-        commit_hash (str): The commit hash to analyze.
-    
-    Returns:
-        set: A set of function names that were changed in the commit.
-    """
     os.chdir(repo_path)
     diff = subprocess.check_output(["git", "diff", commit_hash, "--", "*.py"], text=True)
     return {line.split()[3].split('(')[0].strip('+') for line in diff.split('\n') 
             if line.startswith('@@') and len(line.split()) > 3 and '(' in line.split()[3]}
 
 def find_test_functions(project_dir):
-    """
-    Finds all test functions in the project directory.
-    
-    Args:
-        project_dir (str): Path to the project root directory.
-    
-    Returns:
-        list: A list of dictionaries containing test function details (file, test_name, and calls).
-    """
     tests = []
     for root, _, files in os.walk(project_dir):
         for file in files:
@@ -48,16 +29,6 @@ def find_test_functions(project_dir):
     return tests
 
 def find_impacted_tests(project_dir, changed_funcs):
-    """
-    Identifies test functions that are impacted by the changed functions.
-    
-    Args:
-        project_dir (str): Path to the project root directory.
-        changed_funcs (set): A set of function names that were changed.
-    
-    Returns:
-        list: A list of dictionaries containing impacted test details (file, test_name, and called_function).
-    """
     tests = find_test_functions(project_dir)
     return [{
         "file": test["file"],
@@ -70,14 +41,6 @@ def find_impacted_tests(project_dir, changed_funcs):
 @click.option('--commit', required=True, help='Commit hash to analyze')
 @click.option('--project', required=True, help='Path to the project root')
 def cli(repo, commit, project):
-    """
-    CLI entry point to analyze impacted tests based on changed functions in a commit.
-    
-    Args:
-        repo (str): Path to the repository.
-        commit (str): Commit hash to analyze.
-        project (str): Path to the project root.
-    """
     changed_funcs = get_changed_functions(repo, commit)
     if not changed_funcs:
         click.echo("No functions were modified.")


### PR DESCRIPTION
This pull request is linked to issue #3411.
    The main significant changes in the updated code are as follows:

1. **Removed Docstrings**: All docstrings from the functions (`get_changed_functions`, `find_test_functions`, `find_impacted_tests`, and `cli`) have been removed. While this reduces the verbosity of the code, it also removes the inline documentation that explains the purpose, arguments, and return values of each function. This could make the code less maintainable and harder to understand for new contributors.

2. **No Functional Changes**: The core logic and functionality of the code remain unchanged. The functions still perform the same operations: identifying changed functions in a Git commit, finding test functions in a project directory, and determining which tests are impacted by the changed functions. The CLI interface also remains the same, accepting the same arguments and producing the same output.

3. **Code Readability Impact**: The removal of docstrings impacts the readability and maintainability of the code, especially in a large project with many contributors. Docstrings are essential for understanding the purpose of functions without diving into the implementation details.

4. **No Structural Changes**: The structure of the code, including the order of functions and the use of external libraries (`os`, `subprocess`, `json`, `click`, `parso`), remains consistent. The logic for parsing Python files, extracting function names, and matching test functions with changed functions is unchanged.

In summary, the primary change is the removal of docstrings, which affects the code's documentation and readability but does not alter its functionality or structure.

Closes #3411