### PR TITLE
Bump `trl` library version from 0.15.0 to 0.16.0 for latest features and improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.15.0
+trl==0.16.0


### PR DESCRIPTION
This pull request is linked to issue #3449.
    The primary change in this update is the version bump of the `trl` library from `0.15.0` to `0.16.0`. This update likely includes new features, bug fixes, or performance improvements in the `trl` package, which is used for training and fine-tuning transformer-based models with reinforcement learning. The rest of the dependencies, including `torch`, `transformers`, `datasets`, `accelerate`, `deepspeed`, `peft`, and others, remain unchanged, ensuring compatibility with the existing codebase while leveraging the enhancements in `trl`. This change aligns with maintaining up-to-date dependencies to benefit from the latest advancements in the ecosystem.

Closes #3449