### PR TITLE
Bump `trl` library version from 0.14.0 to 0.17.0 for new features and improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.16.0
+trl==0.17.0


### PR DESCRIPTION
This pull request is linked to issue #3451.
    The main significant change in this update is the version bump of the `trl` library from `0.14.0` to `0.17.0`. This is a notable upgrade as it includes new features, bug fixes, and potentially performance improvements or API changes. The rest of the dependencies remain unchanged, ensuring compatibility with the existing codebase while leveraging the enhancements provided by the newer version of `trl`. This update aligns with the ongoing development and maintenance of the project, ensuring it stays up-to-date with the latest advancements in the ecosystem.

Closes #3451