### PR TITLE
Refactor variable and function names for improved clarity and readability

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -5,77 +5,77 @@ from sklearn.manifold import TSNE
 import random
 from tensorflow.keras import layers
 
-create_embedding_model = lambda embedding_dim, feature_dim: tf.keras.Sequential([
-    layers.Embedding(embedding_dim, feature_dim),
+build_embedding_network = lambda embedding_size, feature_size: tf.keras.Sequential([
+    layers.Embedding(embedding_size, feature_size),
     layers.GlobalAveragePooling1D(),
-    layers.Dense(feature_dim),
+    layers.Dense(feature_size),
     layers.BatchNormalization(),
     layers.LayerNormalization()
 ])
 
-generate_random_dataset = lambda size: (np.random.randint(0, 100, (size, 10)), np.random.randint(0, 2, size))
+generate_random_data = lambda data_size: (np.random.randint(0, 100, (data_size, 10)), np.random.randint(0, 2, data_size))
 
-create_triplet_data = lambda samples, labels, negative_count: tf.data.Dataset.from_tensor_slices((samples, labels)).map(
-    lambda anchor, label: (
-        anchor,
-        tf.convert_to_tensor(random.choice(samples[labels == label.numpy()])),
-        tf.convert_to_tensor(random.sample(samples[labels != label.numpy()].tolist(), negative_count))
+create_triplet_dataset = lambda data_samples, data_labels, num_negatives: tf.data.Dataset.from_tensor_slices((data_samples, data_labels)).map(
+    lambda anchor_sample, anchor_label: (
+        anchor_sample,
+        tf.convert_to_tensor(random.choice(data_samples[data_labels == anchor_label.numpy()])),
+        tf.convert_to_tensor(random.sample(data_samples[data_labels != anchor_label.numpy()].tolist(), num_negatives))
     )
 )
 
-triplet_loss_function = lambda margin=1.0: lambda anchor, positive, negative: tf.reduce_mean(
+compute_triplet_loss = lambda margin=1.0: lambda anchor, positive, negative: tf.reduce_mean(
     tf.maximum(tf.norm(anchor - positive, axis=1) - tf.reduce_min(tf.norm(anchor[:, tf.newaxis] - negative, axis=2), axis=1) + margin, 0.0)
 )
 
-train_embedding_model = lambda model, dataset, epochs, learning_rate: (
-    lambda optimizer, loss_fn: [
+train_embedding_network = lambda network, dataset, num_epochs, lr: (
+    lambda optimizer, loss_function: [
         (lambda epoch_loss: [
             (lambda anchors, positives, negatives: (
-                (lambda loss: optimizer.apply_gradients(zip(tf.GradientTape().gradient(loss, model.trainable_variables), model.trainable_variables))(
-                    loss_fn(anchors, positives, negatives)
+                (lambda loss: optimizer.apply_gradients(zip(tf.GradientTape().gradient(loss, network.trainable_variables), network.trainable_variables))(
+                    loss_function(anchors, positives, negatives)
                 )
             )(*batch) for batch in dataset.batch(32)
-        ] and loss_history.append(epoch_loss / len(dataset)) for _ in range(epochs)
-    ])(tf.keras.optimizers.Adam(learning_rate), triplet_loss_function()), []
+        ] and loss_history.append(epoch_loss / len(dataset)) for _ in range(num_epochs)
+    ])(tf.keras.optimizers.Adam(lr), compute_triplet_loss()), []
 )
 
-evaluate_model = lambda model, samples, labels, k=5: (
+evaluate_network = lambda network, data_samples, data_labels, k=5: (
     lambda embeddings: (
-        display_metrics(calculate_knn_metrics(embeddings, labels, k)),
-        plot_embeddings(embeddings, labels)
+        display_performance_metrics(compute_knn_metrics(embeddings, data_labels, k)),
+        visualize_embeddings(embeddings, data_labels)
     )
-)(model(tf.convert_to_tensor(samples, dtype=tf.int32)).numpy())
+)(network(tf.convert_to_tensor(data_samples, dtype=tf.int32)).numpy())
 
-display_metrics = lambda metrics: (
+display_performance_metrics = lambda metrics: (
     print(f"Accuracy: {metrics[0]:.4f}"),
     print(f"Precision: {metrics[1]:.4f}"),
     print(f"Recall: {metrics[2]:.4f}"),
     print(f"F1-score: {metrics[3]:.4f}")
 )
 
-save_model = lambda model, filepath: model.save_weights(filepath)
+save_network = lambda network, filepath: network.save_weights(filepath)
 
-load_model = lambda model_class, filepath: (lambda model: model.load_weights(filepath) or model)(model_class())
+load_network = lambda network_class, filepath: (lambda network: network.load_weights(filepath) or network)(network_class())
 
-get_embeddings = lambda model, input_data: model(tf.convert_to_tensor(input_data, dtype=tf.int32)).numpy()
+extract_embeddings = lambda network, input_data: network(tf.convert_to_tensor(input_data, dtype=tf.int32)).numpy()
 
-plot_embeddings = lambda embeddings, labels: (
+visualize_embeddings = lambda embeddings, labels: (
     plt.figure(figsize=(8, 8)),
     plt.scatter(TSNE(n_components=2).fit_transform(embeddings)[:, 0], TSNE(n_components=2).fit_transform(embeddings)[:, 1], c=labels, cmap='viridis'),
     plt.colorbar(),
     plt.show()
 )
 
-calculate_knn_metrics = lambda embeddings, labels, k=5: (
-    lambda dist_matrix, nearest_indices, true_positives: (
-        np.mean(np.any(labels[nearest_indices] == labels[:, np.newaxis], axis=1)),
+compute_knn_metrics = lambda embeddings, labels, k=5: (
+    lambda distance_matrix, nearest_neighbors, true_positives: (
+        np.mean(np.any(labels[nearest_neighbors] == labels[:, np.newaxis], axis=1)),
         np.mean(true_positives / k),
         np.mean(true_positives / np.sum(labels == labels[:, np.newaxis], axis=1)),
         2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0
     )
-)(np.linalg.norm(embeddings[:, np.newaxis] - embeddings, axis=2), np.argsort(dist_matrix, axis=1)[:, 1:k + 1], np.sum(labels[nearest_indices] == labels[:, np.newaxis], axis=1))
+)(np.linalg.norm(embeddings[:, np.newaxis] - embeddings, axis=2), np.argsort(distance_matrix, axis=1)[:, 1:k + 1], np.sum(labels[nearest_neighbors] == labels[:, np.newaxis], axis=1))
 
-plot_training_loss = lambda loss_history: (
+plot_loss_history = lambda loss_history: (
     plt.figure(figsize=(10, 5)),
     plt.plot(loss_history, label='Loss', color='blue'),
     plt.title('Training Loss Over Epochs'),
@@ -85,16 +85,16 @@ plot_training_loss = lambda loss_history: (
     plt.show()
 )
 
-execute_training_pipeline = lambda learning_rate, batch_size, epochs, negative_count, embedding_dim, feature_dim, data_size: (
-    lambda samples, labels, triplet_data, model: (
-        save_model(model, "triplet_model.h5"),
-        plot_training_loss(train_embedding_model(model, triplet_data, epochs, learning_rate)),
-        evaluate_model(model, samples, labels)
+run_training_pipeline = lambda lr, batch_size, num_epochs, num_negatives, embedding_size, feature_size, data_size: (
+    lambda data_samples, data_labels, triplet_dataset, network: (
+        save_network(network, "triplet_network.h5"),
+        plot_loss_history(train_embedding_network(network, triplet_dataset, num_epochs, lr)),
+        evaluate_network(network, data_samples, data_labels)
     )
-)(*generate_random_dataset(data_size), create_triplet_data(samples, labels, negative_count), create_embedding_model(embedding_dim, feature_dim))
+)(*generate_random_data(data_size), create_triplet_dataset(data_samples, data_labels, num_negatives), build_embedding_network(embedding_size, feature_size))
 
-display_model_summary = lambda model: model.summary()
+display_network_summary = lambda network: network.summary()
 
 if __name__ == "__main__":
-    execute_training_pipeline(1e-4, 32, 10, 5, 101, 10, 100)
-    display_model_summary(create_embedding_model(101, 10))
+    run_training_pipeline(1e-4, 32, 10, 5, 101, 10, 100)
+    display_network_summary(build_embedding_network(101, 10))


### PR DESCRIPTION
This pull request is linked to issue #3455.
    The main changes in this update are primarily focused on renaming variables and functions for improved clarity and readability, without altering the core functionality of the code. Here's a breakdown of the significant changes:

1. Function and variable renaming for better readability:
   - `create_embedding_model` is now `build_embedding_network`
   - `generate_random_dataset` is now `generate_random_data`
   - `create_triplet_data` is now `create_triplet_dataset`
   - `triplet_loss_function` is now `compute_triplet_loss`
   - `train_embedding_model` is now `train_embedding_network`
   - `evaluate_model` is now `evaluate_network`
   - `display_metrics` is now `display_performance_metrics`
   - `save_model` is now `save_network`
   - `load_model` is now `load_network`
   - `get_embeddings` is now `extract_embeddings`
   - `plot_embeddings` is now `visualize_embeddings`
   - `calculate_knn_metrics` is now `compute_knn_metrics`
   - `plot_training_loss` is now `plot_loss_history`
   - `execute_training_pipeline` is now `run_training_pipeline`
   - `display_model_summary` is now `display_network_summary`

2. Parameter renaming for consistency:
   - `embedding_dim` is now `embedding_size`
   - `feature_dim` is now `feature_size`
   - `size` is now `data_size`
   - `negative_count` is now `num_negatives`
   - `epochs` is now `num_epochs`
   - `learning_rate` is now `lr`
   - `samples` is now `data_samples`
   - `labels` is now `data_labels`
   - `model` is now `network`

3. File naming update:
   - The saved model file is renamed from `triplet_model.h5` to `triplet_network.h5`

These changes maintain the same logic and functionality while improving code readability and consistency in naming conventions. The structure and flow of the code remain unchanged, ensuring that the behavior of the program is identical to the previous version.

Closes #3455