### PR TITLE
Bump `trl` library version from 0.22.0 to 0.23.0 for updates and improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.22.0
+trl==0.23.0


### PR DESCRIPTION
This pull request is linked to issue #3515.
    The main significant change in this update is the version bump of the `trl` library from `0.22.0` to `0.23.0`. This update likely includes bug fixes, performance improvements, or new features introduced in the latest version of `trl`. No other dependencies have been modified, ensuring compatibility with the existing environment while leveraging the enhancements provided by the newer `trl` version. This change aligns with maintaining up-to-date dependencies to benefit from the latest advancements and stability improvements in the library.

Closes #3515