### PR TITLE
Bump `trl` library version from 0.23.0 to 0.24.0 for stability and enhancements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.23.0
+trl==0.24.0


### PR DESCRIPTION
This pull request is linked to issue #3521.
    The main significant change in this update is the version bump of the `trl` library from `0.23.0` to `0.24.0`. This update likely includes bug fixes, performance improvements, or new features introduced in the `trl` library. No other dependencies have been modified, ensuring compatibility with the existing stack while leveraging the latest enhancements from `trl`. This change aligns with maintaining up-to-date dependencies for improved stability and functionality.

Closes #3521