### PR TITLE
Replace libcst with ast module, simplify node attribute access, and improve parsing and function call extraction

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import json
 import click
-from libcst import parse_module, FunctionDef, Call, Name
+from ast import parse, FunctionDef, Call, Name, AST
 
 PYTHON_EXEC = "python3"
 
@@ -19,13 +19,13 @@ def locate_test_functions(project_root):
             if filename.endswith(".py"):
                 file_path = os.path.join(root_dir, filename)
                 with open(file_path, "r", encoding="utf-8") as file:
-                    module_content = parse_module(file.read())
+                    module_content = parse(file.read(), filename=file_path)
                 for node in module_content.body:
-                    if isinstance(node, FunctionDef) and "test" in node.name.value:
-                        function_calls = [n.func.value for n in module_content.body if isinstance(n, Call) and isinstance(n.func, Name)]
+                    if isinstance(node, FunctionDef) and "test" in node.name:
+                        function_calls = [n.func.id for n in module_content.body if isinstance(n, Call) and isinstance(n.func, Name)]
                         test_functions.append({
                             "file_path": file_path,
-                            "test_function": node.name.value,
+                            "test_function": node.name,
                             "function_calls": function_calls
                         })
     return test_functions


### PR DESCRIPTION
This pull request is linked to issue #3527.
    The main significant changes in the updated code are as follows:

1. **AST Module Replacement**: The code now uses Python's built-in `ast` module instead of `libcst` for parsing Python files. This change simplifies dependencies and leverages the standard library, reducing external package requirements. The `parse_module` function from `libcst` is replaced with `parse` from `ast`.

2. **Node Attribute Access**: The way node attributes are accessed has been updated. In the original code, `node.name.value` was used to access the function name, whereas in the updated code, `node.name` is used directly. Similarly, `n.func.value` is replaced with `n.func.id` for accessing function call names. This aligns with the `ast` module's attribute naming conventions.

3. **Module Parsing**: The `parse` function from `ast` now includes the `filename` parameter, which provides better context for debugging and error handling during parsing. This is a minor but useful improvement for traceability.

4. **Simplified Function Calls Extraction**: The extraction of function calls within test functions has been streamlined. The updated code directly accesses `n.func.id` instead of `n.func.value`, which is more consistent with the `ast` module's structure.

These changes improve code maintainability by reducing external dependencies and aligning with Python's standard library conventions. The functionality remains the same, but the implementation is now more lightweight and consistent with Python's built-in tools.

Closes #3527