### PR TITLE
Upgrade `trl` library from v0.25.0 to v0.26.0 for enhanced stability and functionality.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.25.0
+trl==0.26.0


### PR DESCRIPTION
This pull request is linked to issue #3537.
    The main significant change in this update is the upgrade of the `trl` library from version `0.25.0` to `0.26.0`. This version bump likely includes bug fixes, performance improvements, or new features introduced in the `trl` library. No other dependencies have been modified, ensuring compatibility with the existing environment while benefiting from the enhancements in the latest `trl` release. This change aligns with maintaining up-to-date dependencies for improved stability and functionality.

Closes #3537