### PR TITLE
Bump `trl` library version from 0.28.0 to 0.28.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.28.0
+trl==0.28.1


### PR DESCRIPTION
This pull request is linked to issue #3549.
    The main significant change in this update is the version bump of the `trl` library from `0.28.0` to `0.28.1`. This is a minor version update, which typically includes bug fixes, performance improvements, or minor feature enhancements. The rest of the dependencies remain unchanged, ensuring compatibility with the existing codebase. This update does not introduce breaking changes or require modifications to the existing implementation, as it is a patch-level update within the same minor version.

Closes #3549