### PR TITLE
Bump `trl` library version from 0.28.1 to 0.28.2 for stability and minor improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.28.1
+trl==0.28.2


### PR DESCRIPTION
This pull request is linked to issue #3551.
    The main significant change in this update is the version bump of the `trl` library from `0.28.1` to `0.28.2`. This is a patch-level update, which typically includes bug fixes, minor improvements, or security patches rather than introducing new features or breaking changes. The rest of the dependencies remain unchanged, ensuring compatibility with the existing codebase while addressing potential issues or optimizations in the `trl` library. This update aligns with maintaining stability and reliability in the project's dependencies.

Closes #3551