### PR TITLE
Bump `trl` library version from 0.28.2 to 0.28.3 for bug fixes and stability improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ tokenizers==0.21.0
 tqdm==4.68.0
 PyYAML==6.4.0
 safetensors==0.11.0
-trl==0.28.2
+trl==0.28.3


### PR DESCRIPTION
This pull request is linked to issue #3555.
    The main significant change in this update is the version bump of the `trl` library from `0.28.2` to `0.28.3`. This is a patch-level update, which typically includes bug fixes, minor improvements, or security patches rather than introducing new features or breaking changes. The rest of the dependencies, including `torch`, `transformers`, `datasets`, and others, remain unchanged, ensuring compatibility with the existing codebase. This update aims to resolve any potential issues or bugs present in the previous version of `trl` while maintaining stability across the ecosystem.

Closes #3555