### PR TITLE
Improve CLI help text and error messaging for clarity and consistency

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -39,13 +39,13 @@ def identify_affected_tests(project_root, modified_functions):
     } for test in test_functions for call in test["function_calls"] if call in modified_functions]
 
 @click.command()
-@click.option('--repo', required=True, help='Path to the repository')
-@click.option('--commit', required=True, help='Commit hash to analyze')
-@click.option('--project', required=True, help='Path to the project root')
+@click.option('--repo', required=True, help='Directory containing the repository')
+@click.option('--commit', required=True, help='Specific commit to examine')
+@click.option('--project', required=True, help='Root directory of the project')
 def main(repo, commit, project):
     modified_functions = fetch_modified_functions(repo, commit)
     if not modified_functions:
-        click.echo("No functions were modified.")
+        click.echo("No changes detected in functions.")
         return
     click.echo(json.dumps(identify_affected_tests(project, modified_functions), indent=2))
 


### PR DESCRIPTION
This pull request is linked to issue #3557.
    The main significant changes in the updated code are focused on improving clarity and consistency in the command-line interface (CLI) descriptions and error messaging. Specifically:

1. The help text for the `--repo` option has been updated from "Path to the repository" to "Directory containing the repository" to better describe the expected input. This change ensures users understand they should provide a directory path, not just any path.

2. The help text for the `--commit` option has been refined from "Commit hash to analyze" to "Specific commit to examine." This wording is more precise and aligns with common Git terminology, making it clearer for users.

3. The help text for the `--project` option has been updated from "Path to the project root" to "Root directory of the project." This change emphasizes that the input should be the root directory, avoiding potential confusion.

4. The error message when no modified functions are detected has been updated from "No functions were modified" to "No changes detected in functions." This phrasing is more concise and aligns better with the context of the operation.

These changes are minor but improve the user experience by making the CLI more intuitive and the messaging more consistent with common development practices. No functional changes were made to the core logic of the code.

Closes #3557