### PR TITLE
Fix typo in numpy version specification from `.26.3` to `1.26.3`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ tree-sitter-languages==1.8.0
 scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.15.0
-numpy==.26.3
+numpy==1.26.3
 subprocess-run==1.0.0


### PR DESCRIPTION
This pull request is linked to issue #3572.
    The main significant changes in the updated code are as follows:

1. Fixed a typo in the `numpy` version specification. The original code had `numpy==.26.3`, which is incorrect. This has been corrected to `numpy==1.26.3`. This ensures that the correct version of the `numpy` library is installed, avoiding potential installation errors or version mismatches.

No other changes were made to the dependencies or their versions. The rest of the packages remain unchanged, ensuring compatibility and stability across the project. This fix is crucial for maintaining a smooth installation process and avoiding runtime issues related to the `numpy` library.

Closes #3572