### PR TITLE
Refactor function and variable names for improved clarity and readability

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -6,60 +6,39 @@ from ast import parse, FunctionDef, Call, Name
 
 PYTHON_INTERPRETER = "python3"
 
-def get_changed_functions(repo_path, commit_hash):
+def extract_diff_functions(repo_path, commit_hash):
     os.chdir(repo_path)
-    diff_output = subprocess.check_output(["git", "diff", commit_hash, "--", "*.py"], text=True)
-    return {
-        func.split('(')[0].strip('+') 
-        for line in diff_output.split('\n') 
-        if line.startswith('@@') and len(line.split()) > 3 and '(' in (func := line.split()[3])
-    }
+    diff = subprocess.check_output(["git", "diff", commit_hash, "--", "*.py"], text=True)
+    return {func.split('(')[0].strip('+') for line in diff.split('\n') if line.startswith('@@') and len(line.split()) > 3 and '(' in (func := line.split()[3])}
 
-def find_test_methods(project_base):
-    tests = []
-    for dirpath, _, files in os.walk(project_base):
+def scan_for_tests(base_dir):
+    test_cases = []
+    for root, _, files in os.walk(base_dir):
         for file in files:
             if file.endswith(".py"):
-                full_path = os.path.join(dirpath, file)
-                with open(full_path, "r", encoding="utf-8") as f:
-                    ast_tree = parse(f.read(), filename=full_path)
+                file_path = os.path.join(root, file)
+                with open(file_path, "r", encoding="utf-8") as f:
+                    ast_tree = parse(f.read(), filename=file_path)
                 for node in ast_tree.body:
                     if isinstance(node, FunctionDef) and "test" in node.name:
-                        calls = [
-                            n.func.id 
-                            for n in ast_tree.body 
-                            if isinstance(n, Call) and isinstance(n.func, Name)
-                        ]
-                        tests.append({
-                            "path": full_path,
-                            "test_name": node.name,
-                            "calls": calls
-                        })
-    return tests
+                        called_functions = [n.func.id for n in ast_tree.body if isinstance(n, Call) and isinstance(n.func, Name)]
+                        test_cases.append({"path": file_path, "test_name": node.name, "calls": called_functions})
+    return test_cases
 
-def determine_impacted_tests(project_base, changed_funcs):
-    tests = find_test_methods(project_base)
-    return [
-        {
-            "path": test["path"],
-            "test_name": test["test_name"],
-            "called_func": call
-        } 
-        for test in tests 
-        for call in test["calls"] 
-        if call in changed_funcs
-    ]
+def identify_affected_tests(base_dir, modified_functions):
+    test_cases = scan_for_tests(base_dir)
+    return [{"path": test["path"], "test_name": test["test_name"], "called_func": call} for test in test_cases for call in test["calls"] if call in modified_functions]
 
 @click.command()
 @click.option('--repo', required=True, help='Path to the repository')
 @click.option('--commit', required=True, help='Commit hash to analyze')
 @click.option('--project', required=True, help='Base directory of the project')
-def execute(repo, commit, project):
-    changed_funcs = get_changed_functions(repo, commit)
-    if not changed_funcs:
+def run_analysis(repo, commit, project):
+    modified_functions = extract_diff_functions(repo, commit)
+    if not modified_functions:
         click.echo("No function changes found.")
         return
-    click.echo(json.dumps(determine_impacted_tests(project, changed_funcs), indent=2))
+    click.echo(json.dumps(identify_affected_tests(project, modified_functions), indent=2))
 
 if __name__ == "__main__":
-    execute()
+    run_analysis()


### PR DESCRIPTION
This pull request is linked to issue #3592.
    The main changes in this code are primarily focused on renaming functions and variables for better clarity and readability, without altering the core functionality. Here's a breakdown of the significant changes:

1. Function `get_changed_functions` is renamed to `extract_diff_functions` to better reflect its purpose of extracting function names from Git diff output. The logic remains unchanged.

2. Function `find_test_methods` is renamed to `scan_for_tests` to make the name more concise and descriptive. The functionality of scanning the project directory for test methods and their called functions remains the same.

3. Function `determine_impacted_tests` is renamed to `identify_affected_tests` for improved clarity. The logic for identifying which tests are affected by the modified functions is unchanged.

4. The `execute` function is renamed to `run_analysis` to better describe its role in running the analysis workflow. The logic for handling CLI arguments, extracting modified functions, and identifying affected tests remains consistent.

5. Variable names like `diff_output`, `tests`, `changed_funcs`, and `project_base` are updated to `diff`, `test_cases`, `modified_functions`, and `base_dir` respectively, to improve readability and consistency.

These changes are purely refactoring efforts aimed at improving code readability and maintainability, ensuring that the codebase remains clean and understandable for future contributors. No functional changes have been made to the logic or behavior of the code.

Closes #3592