### PR TITLE
Upgrade `subprocess-run` from 1.0.5 to 1.0.6 for compatibility and improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.5
+subprocess-run==1.0.6


### PR DESCRIPTION
This pull request is linked to issue #3608.
    This update primarily focuses on upgrading the `subprocess-run` package from version `1.0.5` to `1.0.6`. The change is minimal but significant as it ensures compatibility with the latest bug fixes and improvements in the `subprocess-run` library. This package is crucial for managing subprocesses in Python, and the update likely includes patches for edge cases, performance optimizations, or security enhancements. No other dependencies were modified, ensuring stability across the rest of the environment. This change aligns with maintaining a secure and efficient codebase while leveraging the latest improvements in the ecosystem.

Closes #3608