### PR TITLE
Bump `subprocess-run` package from 1.0.8 to 1.0.9 for stability and security improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.8
+subprocess-run==1.0.9


### PR DESCRIPTION
This pull request is linked to issue #3622.
    The main significant change in this update is the version bump of the `subprocess-run` package from `1.0.8` to `1.0.9`. This is a minor version update, which typically includes bug fixes, performance improvements, or minor feature enhancements. No other dependencies were modified, ensuring compatibility with the existing codebase while addressing potential issues or improvements in the `subprocess-run` library. This change aligns with maintaining up-to-date dependencies for stability and security.

Closes #3622