### PR TITLE
Bump `subprocess-run` from 1.0.10 to 1.0.11 for bug fixes and improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.10
+subprocess-run==1.0.11


### PR DESCRIPTION
This pull request is linked to issue #3630.
    The main significant change in this update is the version bump of `subprocess-run` from `1.0.10` to `1.0.11`. This minor version update likely includes bug fixes, performance improvements, or additional features related to the `subprocess-run` library, which is used for running subprocesses in Python. No other dependencies were modified, ensuring compatibility with the existing environment while addressing potential issues or enhancements specific to `subprocess-run`. This change aligns with maintaining stability and improving functionality in the project's subprocess management.

Closes #3630