### PR TITLE
Bump `subprocess-run` package from 1.0.17 to 1.0.18 for reliability and security

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.17
+subprocess-run==1.0.18


### PR DESCRIPTION
This pull request is linked to issue #3660.
    The main significant change in this update is the version bump of the `subprocess-run` package from `1.0.17` to `1.0.18`. This is a minor version update, which typically includes bug fixes, performance improvements, or minor feature enhancements. The rest of the dependencies remain unchanged, ensuring compatibility and stability across the project. This update aligns with maintaining up-to-date dependencies for improved reliability and security.

Closes #3660