### PR TITLE
Update `retrieve_model` to require `vocab_dim` and `embed_dim` for robust model initialization

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -75,8 +75,8 @@ def display_metrics(metrics):
 def store_model(model, path):
     torch.save(model.state_dict(), path)
 
-def retrieve_model(model_class, path):
-    model = model_class()
+def retrieve_model(model_class, path, vocab_dim, embed_dim):
+    model = model_class(vocab_dim, embed_dim)
     model.load_state_dict(torch.load(path))
     return model
 


### PR DESCRIPTION
This pull request is linked to issue #3662.
    The main significant changes in the updated code are as follows:

1. **Retrieve Model Function Updated**: The `retrieve_model` function now requires `vocab_dim` and `embed_dim` as parameters. This change ensures that the model is instantiated with the correct dimensions before loading the state dictionary. Previously, the function assumed a default constructor without arguments, which could lead to errors if the model class required specific dimensions.

2. **Model Initialization in `retrieve_model`**: The `retrieve_model` function now initializes the model with `vocab_dim` and `embed_dim` before loading the state dictionary. This ensures compatibility with the `NeuralEmbedder` class, which requires these parameters during initialization. This change prevents potential runtime errors when retrieving a saved model.

3. **No Changes to Core Logic**: The core logic of the model, including the forward pass, loss computation, and training loop, remains unchanged. The modifications are focused on improving the robustness of model retrieval and ensuring that the model is correctly instantiated with the necessary parameters.

These changes enhance the code's reliability, particularly when saving and loading models, by ensuring that the model is correctly initialized with the required dimensions. This prevents potential issues that could arise from incorrect model instantiation during retrieval.

Closes #3662