### PR TITLE
Bump `subprocess-run` to v1.0.19 for compatibility and improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.18
+subprocess-run==1.0.19


### PR DESCRIPTION
This pull request is linked to issue #3674.
    This update primarily focuses on bumping the version of the `subprocess-run` package from `1.0.18` to `1.0.19`. The change is minimal but significant as it ensures compatibility with the latest bug fixes and improvements in the `subprocess-run` library. This package is crucial for handling subprocess execution in Python, and the update likely includes patches for edge cases, security improvements, or performance optimizations. No other dependencies were modified, ensuring stability across the rest of the stack. This aligns with maintaining a secure and efficient development environment while minimizing potential disruptions.

Closes #3674