### PR TITLE
Bump `subprocess-run` package from 1.0.22 to 1.0.23 for minor updates and stability improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.22
+subprocess-run==1.0.23


### PR DESCRIPTION
This pull request is linked to issue #3698.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.22` to `1.0.23`. The change is minimal and does not introduce any breaking modifications or significant feature additions. The update likely includes bug fixes, performance improvements, or minor enhancements to the `subprocess-run` functionality, ensuring better stability and compatibility with the existing codebase. No other dependencies were altered, maintaining consistency across the project's environment. This change aligns with the project's commitment to keeping dependencies up-to-date while minimizing disruptions.

Closes #3698