### PR TITLE
Bump `subprocess-run` from 1.0.24 to 1.0.25 for performance and security updates.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.24
+subprocess-run==1.0.25


### PR DESCRIPTION
This pull request is linked to issue #3702.
    The main significant change in this update is the version bump of `subprocess-run` from `1.0.24` to `1.0.25`. This is a minor version update, likely addressing bug fixes, performance improvements, or security patches. No other dependencies have been modified, ensuring compatibility and stability across the existing stack. This change aligns with maintaining up-to-date dependencies for optimal performance and security.

Closes #3702