### PR TITLE
Bump `subprocess-run` package from 1.0.26 to 1.0.27 for minor updates and stability improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.26
+subprocess-run==1.0.27


### PR DESCRIPTION
This pull request is linked to issue #3716.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.26` to `1.0.27`. The change is minimal and likely includes bug fixes, performance improvements, or minor feature enhancements. No other dependencies were modified, ensuring compatibility with the existing environment. This update aligns with maintaining stability while incorporating the latest improvements from the `subprocess-run` package.

Closes #3716