### PR TITLE
Bump `subprocess-run` package from 1.0.27 to 1.0.28 for minor updates and fixes.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.27
+subprocess-run==1.0.28


### PR DESCRIPTION
This pull request is linked to issue #3718.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.27` to `1.0.28`. The change is minimal and does not introduce any breaking modifications or significant feature additions. The update likely includes bug fixes, performance improvements, or minor enhancements to the existing functionality of the `subprocess-run` library. All other dependencies remain unchanged, ensuring compatibility and stability across the project. This aligns with maintaining a consistent and reliable development environment while addressing potential issues in the `subprocess-run` package.

Closes #3718