### PR TITLE
Bump `subprocess-run` package from 1.0.28 to 1.0.29 for minor updates and stability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.28
+subprocess-run==1.0.29


### PR DESCRIPTION
This pull request is linked to issue #3722.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.28` to `1.0.29`. The change is minimal and does not introduce any breaking modifications or significant feature additions. The update likely includes bug fixes, performance improvements, or minor enhancements to the existing functionality of the `subprocess-run` library. All other dependencies remain unchanged, ensuring compatibility and stability across the project. This aligns with maintaining a secure and up-to-date dependency tree without disrupting the existing workflow or requiring additional adjustments to the codebase.

Closes #3722