### PR TITLE
Bump `subprocess-run` from 1.0.29 to 1.0.30 for minor updates and improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.29
+subprocess-run==1.0.30


### PR DESCRIPTION
This pull request is linked to issue #3726.
    The primary change in this update is the version bump of `subprocess-run` from `1.0.29` to `1.0.30`. This is a minor version update, likely addressing bug fixes, performance improvements, or security patches within the `subprocess-run` package. No other dependencies have been modified, ensuring compatibility with the existing environment. This update aligns with maintaining the latest stable versions of dependencies to leverage improvements and fixes while minimizing potential disruptions.

Closes #3726