### PR TITLE
Add interactive embedding visualization with t-SNE and update main block for enhanced functionality

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -156,6 +156,27 @@ def generate_data(data_size):
     labels = np.random.randint(0, 10, data_size)
     return data, labels
 
+def visualize_embeddings_interactive(model, data, labels):
+    embeddings = generate_embeddings(model, data)
+    tsne_result = TSNE(n_components=2).fit_transform(embeddings)
+    
+    plt.figure(figsize=(8, 8))
+    scatter = plt.scatter(tsne_result[:, 0], tsne_result[:, 1], c=labels, cmap='viridis')
+    plt.colorbar(scatter)
+    
+    def on_click(event):
+        if event.inaxes is not None:
+            x, y = event.xdata, event.ydata
+            distances = np.linalg.norm(tsne_result - np.array([x, y]), axis=1)
+            closest_index = np.argmin(distances)
+            print(f"Clicked on point with label: {labels[closest_index]}")
+    
+    plt.gcf().canvas.mpl_connect('button_press_event', on_click)
+    plt.show()
+
 if __name__ == "__main__":
     run_training(1e-4, 32, 10, 5, 101, 10, 100)
     display_model_architecture(WordVectorGenerator(101, 10))
+    model = load_model(WordVectorGenerator, "word_vector_generator.pth", 101, 10)
+    data, labels = generate_data(100)
+    visualize_embeddings_interactive(model, data, labels)


### PR DESCRIPTION
This pull request is linked to issue #3728.
    The main significant changes in the updated code are as follows:

1. Added a new function `visualize_embeddings_interactive`:
   - This function allows for interactive visualization of embeddings using t-SNE.
   - It generates embeddings from the model and applies t-SNE to reduce dimensions to 2.
   - A scatter plot is created, and an interactive click event is added to display the label of the closest point when clicked.

2. Modified the `if __name__ == "__main__":` block:
   - After running the training and displaying the model architecture, the model is loaded from the saved file.
   - New data and labels are generated.
   - The `visualize_embeddings_interactive` function is called with the loaded model and generated data to enable interactive visualization.

These changes enhance the functionality by providing an interactive way to explore the embeddings, making it easier to understand the model's performance and the relationships between different data points.

Closes #3728