### PR TITLE
Bump `subprocess-run` from 1.0.31 to 1.0.32 for minor updates and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.31
+subprocess-run==1.0.32


### PR DESCRIPTION
This pull request is linked to issue #3734.
    The main change in this update is the version bump of `subprocess-run` from `1.0.31` to `1.0.32`. This is a minor version update, likely addressing bug fixes, performance improvements, or compatibility enhancements. No other dependencies were modified, ensuring stability and consistency across the rest of the environment. This change aligns with maintaining up-to-date dependencies while minimizing potential disruptions to existing workflows.

Closes #3734