### PR TITLE
Bump `subprocess-run` package from 1.0.34 to 1.0.35 for minor updates and stability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.34
+subprocess-run==1.0.35


### PR DESCRIPTION
This pull request is linked to issue #3744.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.34` to `1.0.35`. The change is minimal and likely includes bug fixes, performance improvements, or minor feature enhancements. No other dependencies were updated, ensuring compatibility and stability across the existing stack. This aligns with maintaining a robust and up-to-date environment while minimizing potential disruptions to the codebase.

Closes #3744