### PR TITLE
Bump `subprocess-run` package to version 1.0.36 for minor updates and stability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.35
+subprocess-run==1.0.36


### PR DESCRIPTION
This pull request is linked to issue #3746.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.35` to `1.0.36`. The change is minimal and likely includes bug fixes, performance improvements, or minor feature enhancements. No other dependencies have been updated, ensuring compatibility and stability across the existing stack. This aligns with maintaining a robust and up-to-date environment while minimizing potential disruptions.

Closes #3746