### PR TITLE
Bump `subprocess-run` from 1.0.36 to 1.0.37 for minor updates and stability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.36
+subprocess-run==1.0.37


### PR DESCRIPTION
This pull request is linked to issue #3748.
    The main significant change in this update is the version bump of `subprocess-run` from `1.0.36` to `1.0.37`. This is a minor version update, likely addressing bug fixes, performance improvements, or compatibility enhancements within the `subprocess-run` package. No other dependencies were modified, ensuring that the rest of the environment remains stable and consistent with the previous setup. This change is minimal and should not introduce any breaking changes or require adjustments to existing code.

Closes #3748