### PR TITLE
Bump subprocess-run from 1.0.37 to 1.0.38 for minor updates and stability improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.37
+subprocess-run==1.0.38


### PR DESCRIPTION
This pull request is linked to issue #3756.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.37` to `1.0.38`. The change is minimal and does not introduce any breaking modifications or significant feature additions. The update likely includes bug fixes, performance improvements, or minor enhancements to the `subprocess-run` functionality, ensuring better stability or compatibility with other dependencies. No other dependencies were altered, maintaining consistency across the environment. This change aligns with the project's goal of keeping dependencies up-to-date while minimizing disruption to existing workflows.

Closes #3756