### PR TITLE
Bump `subprocess-run` from 1.0.38 to 1.0.39 for stability and improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.38
+subprocess-run==1.0.39


### PR DESCRIPTION
This pull request is linked to issue #3764.
    The primary change in this update is the version bump of `subprocess-run` from `1.0.38` to `1.0.39`. This is a minor version update, likely addressing bug fixes, performance improvements, or security patches within the `subprocess-run` library. No other dependencies have been modified, ensuring compatibility with the existing environment while incorporating the latest improvements from the `subprocess-run` package. This change aligns with maintaining stability and leveraging updated functionality in the ecosystem.

Closes #3764