### PR TITLE
Bump `subprocess-run` from 1.0.41 to 1.0.42 for stability and security updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.41
+subprocess-run==1.0.42


### PR DESCRIPTION
This pull request is linked to issue #3774.
    The main significant change in this update is the version bump of `subprocess-run` from `1.0.41` to `1.0.42`. This is a minor version update, likely addressing bug fixes, performance improvements, or security patches within the `subprocess-run` library. No other dependencies were modified, ensuring compatibility with the existing environment while incorporating the latest improvements from the `subprocess-run` package. This change aligns with maintaining up-to-date dependencies for stability and security.

Closes #3774