### PR TITLE
Bump `subprocess-run` package to v1.0.45 for minor updates and fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.44
+subprocess-run==1.0.45


### PR DESCRIPTION
This pull request is linked to issue #3796.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.44` to `1.0.45`. The change is minimal and does not introduce breaking modifications but likely includes bug fixes, performance improvements, or security patches as part of its incremental update. No other dependencies were altered, ensuring compatibility and stability across the existing stack. This adjustment aligns with maintaining up-to-date and secure dependencies without disrupting the current workflow or requiring additional changes to the codebase.

Closes #3796