### PR TITLE
Transition from PyTorch to TensorFlow/Keras for model, training, and utility functions

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -1,28 +1,27 @@
-import torch
+import tensorflow as tf
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.manifold import TSNE
 import random
-from torch import nn, optim
-from torch.utils.data import Dataset, DataLoader
+from tensorflow.keras import layers, optimizers, losses
 
-class WordVectorGenerator(nn.Module):
+class WordVectorGenerator(tf.keras.Model):
     def __init__(self, vocab_size, embedding_size):
         super(WordVectorGenerator, self).__init__()
-        self.embedding_layer = nn.Embedding(vocab_size, embedding_size)
-        self.pooling_layer = nn.AdaptiveAvgPool1d(1)
-        self.projection_layer = nn.Linear(embedding_size, embedding_size)
-        self.batch_norm = nn.BatchNorm1d(embedding_size)
-        self.layer_norm = nn.LayerNorm(embedding_size)
+        self.embedding_layer = layers.Embedding(vocab_size, embedding_size)
+        self.pooling_layer = layers.GlobalAveragePooling1D()
+        self.projection_layer = layers.Dense(embedding_size)
+        self.batch_norm = layers.BatchNormalization()
+        self.layer_norm = layers.LayerNormalization()
 
-    def forward(self, input_ids):
+    def call(self, input_ids):
         embeddings = self.embedding_layer(input_ids)
-        pooled = self.pooling_layer(embeddings.transpose(1, 2)).squeeze(2)
+        pooled = self.pooling_layer(embeddings)
         projected = self.projection_layer(pooled)
         normalized = self.batch_norm(projected)
         return self.layer_norm(normalized)
 
-class TripletDataLoader(Dataset):
+class TripletDataLoader(tf.keras.utils.Sequence):
     def __init__(self, data, labels, negative_samples):
         self.data = data
         self.labels = labels
@@ -36,33 +35,33 @@ class TripletDataLoader(Dataset):
         anchor_label = self.labels[index]
         positive = random.choice(self.data[self.labels == anchor_label])
         negatives = random.sample(self.data[self.labels != anchor_label].tolist(), self.negative_samples)
-        return torch.tensor(anchor, dtype=torch.long), torch.tensor(positive, dtype=torch.long), torch.tensor(negatives, dtype=torch.long)
+        return tf.convert_to_tensor(anchor, dtype=tf.int32), tf.convert_to_tensor(positive, dtype=tf.int32), tf.convert_to_tensor(negatives, dtype=tf.int32)
 
 def calculate_triplet_loss(anchor, positive, negative, margin=1.0):
-    positive_distance = torch.norm(anchor - positive, dim=1)
-    negative_distance = torch.min(torch.norm(anchor.unsqueeze(1) - negative, dim=2), dim=1)[0]
-    return torch.mean(torch.clamp(positive_distance - negative_distance + margin, min=0.0))
+    positive_distance = tf.norm(anchor - positive, axis=1)
+    negative_distance = tf.reduce_min(tf.norm(tf.expand_dims(anchor, 1) - negative, axis=2), axis=1)
+    return tf.reduce_mean(tf.maximum(positive_distance - negative_distance + margin, 0.0))
 
 def train_vector_generator(model, dataset, num_epochs, learning_rate):
-    optimizer = optim.Adam(model.parameters(), lr=learning_rate)
+    optimizer = optimizers.Adam(learning_rate=learning_rate)
     loss_history = []
 
     for epoch in range(num_epochs):
         epoch_loss = 0.0
-        for anchor, positive, negative in DataLoader(dataset, batch_size=32, shuffle=True):
-            optimizer.zero_grad()
-            anchor_vector = model(anchor)
-            positive_vector = model(positive)
-            negative_vector = model(negative)
-            loss = calculate_triplet_loss(anchor_vector, positive_vector, negative_vector)
-            loss.backward()
-            optimizer.step()
-            epoch_loss += loss.item()
+        for anchor, positive, negative in dataset:
+            with tf.GradientTape() as tape:
+                anchor_vector = model(anchor)
+                positive_vector = model(positive)
+                negative_vector = model(negative)
+                loss = calculate_triplet_loss(anchor_vector, positive_vector, negative_vector)
+            gradients = tape.gradient(loss, model.trainable_variables)
+            optimizer.apply_gradients(zip(gradients, model.trainable_variables))
+            epoch_loss += loss.numpy()
         loss_history.append(epoch_loss / len(dataset))
     return loss_history
 
 def evaluate_model(model, data, labels, k=5):
-    embeddings = model(torch.tensor(data, dtype=torch.long)).detach().numpy()
+    embeddings = model(tf.convert_to_tensor(data, dtype=tf.int32)).numpy()
     show_metrics(compute_performance_metrics(embeddings, labels, k))
     plot_embeddings(embeddings, labels)
 
@@ -73,15 +72,15 @@ def show_metrics(metrics):
     print(f"F1-score: {metrics[3]:.4f}")
 
 def save_model(model, file_path):
-    torch.save(model.state_dict(), file_path)
+    model.save_weights(file_path)
 
 def load_model(model_class, file_path, vocab_size, embedding_size):
     model = model_class(vocab_size, embedding_size)
-    model.load_state_dict(torch.load(file_path))
+    model.load_weights(file_path)
     return model
 
 def generate_embeddings(model, data):
-    return model(torch.tensor(data, dtype=torch.long)).detach().numpy()
+    return model(tf.convert_to_tensor(data, dtype=tf.int32)).numpy()
 
 def plot_embeddings(embeddings, labels):
     plt.figure(figsize=(8, 8))
@@ -113,31 +112,31 @@ def run_training(learning_rate, batch_size, num_epochs, negative_samples, vocab_
     data, labels = generate_data(data_size)
     dataset = TripletDataLoader(data, labels, negative_samples)
     model = WordVectorGenerator(vocab_size, embedding_size)
-    save_model(model, "word_vector_generator.pth")
+    save_model(model, "word_vector_generator.h5")
     loss_history = train_vector_generator(model, dataset, num_epochs, learning_rate)
     plot_loss_history(loss_history)
     evaluate_model(model, data, labels)
 
 def display_model_architecture(model):
-    print(model)
+    model.summary()
 
 def train_with_early_termination(model, dataset, num_epochs, learning_rate, patience=5):
-    optimizer = optim.Adam(model.parameters(), lr=learning_rate)
+    optimizer = optimizers.Adam(learning_rate=learning_rate)
     loss_history = []
     best_loss = float('inf')
     no_improvement = 0
 
     for epoch in range(num_epochs):
         epoch_loss = 0.0
-        for anchor, positive, negative in DataLoader(dataset, batch_size=32, shuffle=True):
-            optimizer.zero_grad()
-            anchor_vector = model(anchor)
-            positive_vector = model(positive)
-            negative_vector = model(negative)
-            loss = calculate_triplet_loss(anchor_vector, positive_vector, negative_vector)
-            loss.backward()
-            optimizer.step()
-            epoch_loss += loss.item()
+        for anchor, positive, negative in dataset:
+            with tf.GradientTape() as tape:
+                anchor_vector = model(anchor)
+                positive_vector = model(positive)
+                negative_vector = model(negative)
+                loss = calculate_triplet_loss(anchor_vector, positive_vector, negative_vector)
+            gradients = tape.gradient(loss, model.trainable_variables)
+            optimizer.apply_gradients(zip(gradients, model.trainable_variables))
+            epoch_loss += loss.numpy()
         avg_loss = epoch_loss / len(dataset))
         loss_history.append(avg_loss)
 
@@ -176,16 +175,16 @@ def visualize_embeddings_interactive(model, data, labels):
 
 def add_custom_regularization(model, lambda_reg=0.01):
     regularization_loss = 0
-    for param in model.parameters():
-        regularization_loss += torch.norm(param, p=2)
+    for param in model.trainable_variables:
+        regularization_loss += tf.norm(param, ord=2)
     return lambda_reg * regularization_loss
 
 def add_learning_rate_scheduler(optimizer, step_size=30, gamma=0.1):
-    return optim.lr_scheduler.StepLR(optimizer, step_size=step_size, gamma=gamma)
+    return optimizers.schedules.ExponentialDecay(initial_learning_rate=optimizer.learning_rate, decay_steps=step_size, decay_rate=gamma)
 
 if __name__ == "__main__":
     run_training(1e-4, 32, 10, 5, 101, 10, 100)
     display_model_architecture(WordVectorGenerator(101, 10))
-    model = load_model(WordVectorGenerator, "word_vector_generator.pth", 101, 10)
+    model = load_model(WordVectorGenerator, "word_vector_generator.h5", 101, 10)
     data, labels = generate_data(100)
     visualize_embeddings_interactive(model, data, labels)


### PR DESCRIPTION
This pull request is linked to issue #3810.
    The main significant changes in the updated code involve transitioning from PyTorch to TensorFlow/Keras, which impacts the model definition, training loop, and utility functions. Here's a breakdown of the key changes:

1. Model Definition: The `WordVectorGenerator` class now inherits from `tf.keras.Model` instead of `nn.Module`. Layers like `nn.Embedding`, `nn.AdaptiveAvgPool1d`, and `nn.Linear` are replaced with TensorFlow equivalents: `layers.Embedding`, `layers.GlobalAveragePooling1D`, and `layers.Dense`. The `forward` method is renamed to `call`.

2. Data Loading: The `TripletDataLoader` class now inherits from `tf.keras.utils.Sequence`. TensorFlow's `tf.convert_to_tensor` is used instead of PyTorch's `torch.tensor` for converting data to tensors.

3. Loss Calculation: The `calculate_triplet_loss` function now uses TensorFlow operations like `tf.norm` and `tf.reduce_min` instead of PyTorch's `torch.norm` and `torch.min`.

4. Training Loop: The training loop now uses TensorFlow's `tf.GradientTape` for gradient computation and `optimizers.Adam` for optimization. The `train_vector_generator` function has been adapted to use TensorFlow's API for gradient updates.

5. Model Saving/Loading: The `save_model` and `load_model` functions now use TensorFlow's `model.save_weights` and `model.load_weights` instead of PyTorch's `torch.save` and `torch.load`.

6. Utility Functions: Functions like `evaluate_model`, `plot_embeddings`, and `compute_performance_metrics` remain largely unchanged but now use TensorFlow tensors and operations where necessary.

7. Early Stopping and Regularization: The `train_with_early_termination` and `add_custom_regularization` functions have been updated to use TensorFlow's API for loss tracking and regularization.

These changes ensure compatibility with TensorFlow while maintaining the core functionality of the original PyTorch implementation.

Closes #3810