### PR TITLE
Bump `subprocess-run` from 1.0.46 to 1.0.47 for minor updates and security patches.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.46
+subprocess-run==1.0.47


### PR DESCRIPTION
This pull request is linked to issue #3818.
    This update primarily focuses on a minor version bump for the `subprocess-run` package from `1.0.46` to `1.0.47`. The change is minimal and does not introduce any breaking modifications or significant feature additions. The rest of the dependencies remain unchanged, ensuring compatibility and stability across the existing codebase. This update aligns with maintaining up-to-date dependencies for security patches and minor improvements. No additional adjustments to the codebase are required as this is a straightforward dependency upgrade.

Closes #3818