### PR TITLE
Bump subprocess-run package from 1.0.47 to 1.0.48 for minor updates and stability.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.47
+subprocess-run==1.0.48


### PR DESCRIPTION
This pull request is linked to issue #3820.
    This update primarily focuses on a minor version bump for the `subprocess-run` package, moving from version `1.0.47` to `1.0.48`. The change is minimal and likely includes bug fixes, performance improvements, or minor feature enhancements specific to the `subprocess-run` library. No other dependencies have been altered, ensuring compatibility and stability across the existing stack. This update aligns with maintaining up-to-date dependencies while minimizing potential disruptions to the current environment.

Closes #3820