### PR TITLE
Bump `subprocess-run` from 1.0.50 to 1.0.51 for minor updates and security improvements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ scikit-learn==1.4.1
 matplotlib==3.8.2
 tensorflow==2.16.1
 numpy==1.26.4
-subprocess-run==1.0.50
+subprocess-run==1.0.51


### PR DESCRIPTION
This pull request is linked to issue #3828.
    The main significant change in this update is the version bump of `subprocess-run` from `1.0.50` to `1.0.51`. This is a minor version update, likely addressing bug fixes, performance improvements, or security patches within the `subprocess-run` package. No other dependencies were modified, ensuring compatibility with the existing environment. This change aligns with maintaining up-to-date and secure dependencies while minimizing potential disruptions to the current setup.

Closes #3828