### PR TITLE
Add backup_logs() function to create timestamped backups of command log files

### DIFF
--- a/langchain_pipeline.py
+++ b/langchain_pipeline.py
@@ -95,5 +95,16 @@ def execute_with_settings(cmd, max_attempts=5, timer_duration=0):
         countdown(timer_duration)
     start_process(cmd, max_attempts)
 
+def backup_logs():
+    try:
+        with open("command_log.txt", "r") as log_file:
+            logs = log_file.read()
+        with open(f"command_log_backup_{time.strftime('%Y%m%d%H%M%S')}.txt", "w") as backup_file:
+            backup_file.write(logs)
+        logger.success("Logs backed up successfully!")
+    except Exception as e:
+        logger.error(f"Backup failed: {e}")
+
 if __name__ == "__main__":
     click.command()(execute_with_settings)()
+    backup_logs()


### PR DESCRIPTION
This pull request is linked to issue #3844.
    The main significant change in this code is the addition of a new function `backup_logs()` that creates a backup of the command log file. This function reads the contents of `command_log.txt`, writes them to a new file with a timestamp in the filename (e.g., `command_log_backup_YYYYMMDDHHMMSS.txt`), and logs the success or failure of the backup process. This ensures that logs are preserved and can be referenced later, even if the original log file is overwritten or deleted. The function is called at the end of the script execution, right after the `execute_with_settings()` function, ensuring that logs are backed up after the main process completes. This change enhances the reliability and traceability of the system by safeguarding log data.

Closes #3844