### PR TITLE
Upgrade numpy from 1.26.6 to 1.26.7 for bug fixes and performance improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ tree-sitter-languages==1.10.0
 scikit-learn==1.4.3
 matplotlib==3.8.4
 tensorflow==2.16.3
-numpy==1.26.6
+numpy==1.26.7
 subprocess-run==1.0.51


### PR DESCRIPTION
This pull request is linked to issue #3846.
    This update primarily focuses on upgrading the `numpy` package from version `1.26.6` to `1.26.7`. The change is minor and aligns with the latest patch release, which includes bug fixes and performance improvements. No other dependencies have been modified, ensuring compatibility with the existing codebase. This update is backward-compatible and does not introduce breaking changes. The rest of the dependencies remain unchanged to maintain stability and consistency across the project.

Closes #3846