### PR TITLE
Upgrade numpy from 1.26.7 to 1.26.8 for bug fixes and performance improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ tree-sitter-languages==1.10.0
 scikit-learn==1.4.3
 matplotlib==3.8.4
 tensorflow==2.16.3
-numpy==1.26.7
+numpy==1.26.8
 subprocess-run==1.0.51


### PR DESCRIPTION
This pull request is linked to issue #3850.
    The main significant change in this update is the upgrade of the `numpy` package from version `1.26.7` to `1.26.8`. This is a minor version update that likely includes bug fixes, performance improvements, or security patches. No other dependencies have been modified, and all other package versions remain unchanged. This update ensures compatibility with the latest stable release of `numpy` while maintaining the existing functionality of the project.

Closes #3850