### PR TITLE
Update numpy from 1.26.8 to 1.26.9 for bug fixes and performance improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ tree-sitter-languages==1.10.0
 scikit-learn==1.4.3
 matplotlib==3.8.4
 tensorflow==2.16.3
-numpy==1.26.8
+numpy==1.26.9
 subprocess-run==1.0.51


### PR DESCRIPTION
This pull request is linked to issue #3852.
    This PR updates the version of `numpy` from `1.26.8` to `1.26.9`. The change is minor and aligns with the latest patch release in the `1.26.x` series. This update includes bug fixes and performance improvements, ensuring better stability and compatibility with other dependencies. No breaking changes are expected, as this is a patch-level update within the same minor version. The rest of the dependencies remain unchanged, maintaining consistency across the project.

Closes #3852