### PR TITLE
Replace `click` with `typer` for CLI modernization and improved maintainability

### DIFF
--- a/langchain_pipeline.py
+++ b/langchain_pipeline.py
@@ -2,7 +2,7 @@ import os
 import time
 import random
 from subprocess import run
-import click
+import typer
 from tool_library import Tool, create_agent
 from loguru import logger
 from functools import wraps
@@ -106,5 +106,5 @@ def backup_logs():
         logger.error(f"Backup failed: {e}")
 
 if __name__ == "__main__":
-    click.command()(execute_with_settings)()
+    typer.run(execute_with_settings)
     backup_logs()


### PR DESCRIPTION
This pull request is linked to issue #3854.
    The main significant changes in the updated code are as follows:

1. Replaced `click` with `typer`: The CLI framework has been switched from `click` to `typer`. This change simplifies the command-line interface setup, as `typer` is more modern and requires less boilerplate code. The `click.command()` decorator and invocation have been replaced with `typer.run()`.

2. No functional changes: The core logic, including functions like `shuffle_and_categorize`, `process_items`, `show_environment`, `install_pkg`, `run_command`, `setup_tools`, `log_cmd_execution`, `retry_cmd`, `execute_with_retry`, `time_function`, `start_process`, `log_cmd`, `countdown`, `execute_with_settings`, and `backup_logs`, remains unchanged. The behavior and functionality of the code are preserved.

3. Improved readability and maintainability: By switching to `typer`, the codebase becomes more concise and easier to maintain, as `typer` leverages Python type hints and reduces the need for additional decorators or setup code.

These changes focus on modernizing the CLI framework without altering the core functionality, ensuring the code remains efficient and easier to work with.

Closes #3854