### PR TITLE
Migrate codebase from TensorFlow to PyTorch with updated model, data handling, and training logic

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -2,8 +2,10 @@ import json
 import os
 import random
 import numpy as np
-import tensorflow as tf
-from tensorflow.keras import layers, models, optimizers
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import Dataset, DataLoader
 from sklearn.preprocessing import LabelEncoder
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
@@ -19,7 +21,7 @@ class DataProcessor:
     def retrieve_data(self):
         return self.data
 
-class TripletDataset(tf.data.Dataset):
+class TripletDataset(Dataset):
     def __init__(self, data):
         self.data = DataProcessor(data)
         self.samples = self.data.retrieve_data()
@@ -30,23 +32,24 @@ class TripletDataset(tf.data.Dataset):
     def __getitem__(self, idx):
         item = self.samples[idx]
         return {
-            'anchor_seq': tf.convert_to_tensor(self.data.encoder.transform([item['anchor']])[0]),
-            'positive_seq': tf.convert_to_tensor(self.data.encoder.transform([item['positive']])[0]),
-            'negative_seq': tf.convert_to_tensor(self.data.encoder.transform([item['negative']])[0])
+            'anchor_seq': torch.tensor(self.data.encoder.transform([item['anchor']])[0],
+            'positive_seq': torch.tensor(self.data.encoder.transform([item['positive']])[0],
+            'negative_seq': torch.tensor(self.data.encoder.transform([item['negative']])[0]
         }
 
-class EmbeddingModel(models.Model):
+class EmbeddingModel(nn.Module):
     def __init__(self, vocab_size, embed_dim):
         super(EmbeddingModel, self).__init__()
-        self.embedding = layers.Embedding(vocab_size, embed_dim)
-        self.network = models.Sequential([
-            layers.Dense(128, activation='relu'),
-            layers.BatchNormalization(),
-            layers.Dropout(0.2),
-            layers.Dense(128)
-        ])
+        self.embedding = nn.Embedding(vocab_size, embed_dim)
+        self.network = nn.Sequential(
+            nn.Linear(embed_dim, 128),
+            nn.ReLU(),
+            nn.BatchNorm1d(128),
+            nn.Dropout(0.2),
+            nn.Linear(128, 128)
+        )
     
-    def call(self, anchor, positive, negative):
+    def forward(self, anchor, positive, negative):
         return (
             self.network(self.embedding(anchor)),
             self.network(self.embedding(positive)),
@@ -54,23 +57,23 @@ class EmbeddingModel(models.Model):
         )
 
 def calculate_loss(anchor, positive, negative):
-    return tf.reduce_mean(tf.maximum(0.2 + tf.norm(anchor - positive, axis=1) - tf.norm(anchor - negative, axis=1), 0))
+    return torch.mean(torch.clamp(0.2 + torch.norm(anchor - positive, dim=1) - torch.norm(anchor - negative, dim=1), min=0))
 
 def train_model(model, train_data, valid_data, epochs):
-    optimizer = optimizers.Adam(learning_rate=0.001)
-    scheduler = optimizers.schedules.ExponentialDecay(0.001, decay_steps=10, decay_rate=0.1)
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+    scheduler = optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.1)
     history = []
     
     for _ in range(epochs):
         model.train()
         train_loss = 0
         for batch in train_data:
-            with tf.GradientTape() as tape:
-                anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-                loss = calculate_loss(anchor, positive, negative)
-            gradients = tape.gradient(loss, model.trainable_variables)
-            optimizer.apply_gradients(zip(gradients, model.trainable_variables))
-            train_loss += loss.numpy()
+            optimizer.zero_grad()
+            anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+            loss = calculate_loss(anchor, positive, negative)
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.item()
         scheduler.step()
         train_loss /= len(train_data)
         eval_loss, accuracy = evaluate_model(model, valid_data)
@@ -81,14 +84,15 @@ def evaluate_model(model, data):
     model.eval()
     total_loss = 0
     correct = 0
-    for batch in data:
-        anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-        total_loss += calculate_loss(anchor, positive, negative).numpy()
-        correct += count_accurate(anchor, positive, negative)
+    with torch.no_grad():
+        for batch in data:
+            anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+            total_loss += calculate_loss(anchor, positive, negative).item()
+            correct += count_accurate(anchor, positive, negative)
     return total_loss / len(data), correct / len(data.dataset)
 
 def count_accurate(anchor, positive, negative):
-    return tf.reduce_sum(tf.cast(tf.reduce_sum(anchor * positive, axis=1) > tf.reduce_sum(anchor * negative, axis=1), tf.float32))
+    return torch.sum((torch.sum(anchor * positive, dim=1) > torch.sum(anchor * negative, dim=1)).float()
 
 def display_results(history):
     plt.figure(figsize=(10, 5))
@@ -108,20 +112,21 @@ def display_results(history):
     plt.show()
 
 def store_model(model, path):
-    model.save_weights(path)
+    torch.save(model.state_dict(), path)
     print(f'Model saved at {path}')
 
 def load_model(model, path):
-    model.load_weights(path)
+    model.load_state_dict(torch.load(path))
     print(f'Model loaded from {path}')
     return model
 
 def visualize_embeddings(model, data):
     model.eval()
     embeddings = []
-    for batch in data:
-        anchor, _, _ = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-        embeddings.append(anchor.numpy())
+    with torch.no_grad():
+        for batch in data:
+            anchor, _, _ = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+            embeddings.append(anchor.numpy())
     embeddings = np.concatenate(embeddings)
     fig = plt.figure(figsize=(10, 10))
     ax = fig.add_subplot(111, projection='3d')
@@ -144,12 +149,12 @@ def run_pipeline():
     mapping, snippet_files = fetch_data(dataset_path, snippets_dir)
     data = process_data(mapping, snippet_files)
     train_data, valid_data = np.array_split(np.array(data), 2)
-    train_loader = tf.data.Dataset.from_tensor_slices(train_data.tolist()).batch(32).shuffle(True)
-    valid_loader = tf.data.Dataset.from_tensor_slices(valid_data.tolist()).batch(32)
+    train_loader = DataLoader(TripletDataset(train_data.tolist()), batch_size=32, shuffle=True)
+    valid_loader = DataLoader(TripletDataset(valid_data.tolist()), batch_size=32)
     model = EmbeddingModel(vocab_size=len(train_loader.dataset.data.encoder.classes_) + 1, embed_dim=128)
     history = train_model(model, train_loader, valid_loader, epochs=5)
     display_results(history)
-    store_model(model, 'model.h5')
+    store_model(model, 'model.pth')
     visualize_embeddings(model, valid_loader)
 
 def add_feature():


### PR DESCRIPTION
This pull request is linked to issue #3856.
    The main significant changes in the code involve migrating from TensorFlow to PyTorch, which includes several key updates:

1. Framework Migration: The code has been transitioned from TensorFlow to PyTorch. This includes replacing TensorFlow-specific imports with PyTorch equivalents (e.g., `tf` to `torch`, `tensorflow.keras` to `torch.nn`).

2. Dataset and DataLoader: The `TripletDataset` class now inherits from `torch.utils.data.Dataset` instead of `tf.data.Dataset`. The data loading mechanism has been updated to use PyTorch's `DataLoader` for batching and shuffling.

3. Model Definition: The `EmbeddingModel` class now inherits from `nn.Module` instead of `models.Model`. The layers have been updated to PyTorch equivalents (e.g., `layers.Embedding` to `nn.Embedding`, `layers.Dense` to `nn.Linear`).

4. Loss Calculation: The `calculate_loss` function has been updated to use PyTorch operations (`torch.norm`, `torch.clamp`) instead of TensorFlow operations (`tf.norm`, `tf.maximum`).

5. Training Loop: The training loop now uses PyTorch's `optim.Adam` and `optim.lr_scheduler.ExponentialLR` for optimization and learning rate scheduling. The gradient computation and update steps have been adapted to PyTorch's `zero_grad()`, `backward()`, and `step()` methods.

6. Model Saving and Loading: The `store_model` and `load_model` functions now use PyTorch's `torch.save` and `torch.load` for saving and loading model weights.

7. Evaluation and Visualization: The evaluation and visualization functions have been updated to use PyTorch's `torch.no_grad()` context manager for inference.

These changes ensure compatibility with PyTorch while maintaining the core functionality of the original TensorFlow implementation.

Closes #3856