### PR TITLE
Migrate codebase from PyTorch to TensorFlow with updated model, dataset, and training logic

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -2,10 +2,8 @@ import json
 import os
 import random
 import numpy as np
-import torch
-import torch.nn as nn
-import torch.optim as optim
-from torch.utils.data import Dataset, DataLoader
+import tensorflow as tf
+from tensorflow.keras import layers, models, optimizers
 from sklearn.preprocessing import LabelEncoder
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
@@ -21,7 +19,7 @@ class DataProcessor:
     def retrieve_data(self):
         return self.data
 
-class TripletDataset(Dataset):
+class TripletDataset(tf.data.Dataset):
     def __init__(self, data):
         self.data = DataProcessor(data)
         self.samples = self.data.retrieve_data()
@@ -32,24 +30,23 @@ class TripletDataset(Dataset):
     def __getitem__(self, idx):
         item = self.samples[idx]
         return {
-            'anchor_seq': torch.tensor(self.data.encoder.transform([item['anchor']])[0],
-            'positive_seq': torch.tensor(self.data.encoder.transform([item['positive']])[0],
-            'negative_seq': torch.tensor(self.data.encoder.transform([item['negative']])[0]
+            'anchor_seq': tf.convert_to_tensor(self.data.encoder.transform([item['anchor']])[0]),
+            'positive_seq': tf.convert_to_tensor(self.data.encoder.transform([item['positive']])[0]),
+            'negative_seq': tf.convert_to_tensor(self.data.encoder.transform([item['negative']])[0])
         }
 
-class EmbeddingModel(nn.Module):
+class EmbeddingModel(models.Model):
     def __init__(self, vocab_size, embed_dim):
         super(EmbeddingModel, self).__init__()
-        self.embedding = nn.Embedding(vocab_size, embed_dim)
-        self.network = nn.Sequential(
-            nn.Linear(embed_dim, 128),
-            nn.ReLU(),
-            nn.BatchNorm1d(128),
-            nn.Dropout(0.2),
-            nn.Linear(128, 128)
-        )
+        self.embedding = layers.Embedding(vocab_size, embed_dim)
+        self.network = models.Sequential([
+            layers.Dense(128, activation='relu'),
+            layers.BatchNormalization(),
+            layers.Dropout(0.2),
+            layers.Dense(128)
+        ])
     
-    def forward(self, anchor, positive, negative):
+    def call(self, anchor, positive, negative):
         return (
             self.network(self.embedding(anchor)),
             self.network(self.embedding(positive)),
@@ -57,24 +54,23 @@ class EmbeddingModel(nn.Module):
         )
 
 def calculate_loss(anchor, positive, negative):
-    return torch.mean(torch.clamp(0.2 + torch.norm(anchor - positive, dim=1) - torch.norm(anchor - negative, dim=1), min=0))
+    return tf.reduce_mean(tf.maximum(0.2 + tf.norm(anchor - positive, axis=1) - tf.norm(anchor - negative, axis=1), 0))
 
 def train_model(model, train_data, valid_data, epochs):
-    optimizer = optim.Adam(model.parameters(), lr=0.001)
-    scheduler = optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.1)
+    optimizer = optimizers.Adam(learning_rate=0.001)
+    scheduler = optimizers.schedules.ExponentialDecay(0.001, decay_steps=1000, decay_rate=0.1)
     history = []
     
     for _ in range(epochs):
         model.train()
         train_loss = 0
         for batch in train_data:
-            optimizer.zero_grad()
-            anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-            loss = calculate_loss(anchor, positive, negative)
-            loss.backward()
-            optimizer.step()
-            train_loss += loss.item()
-        scheduler.step()
+            with tf.GradientTape() as tape:
+                anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+                loss = calculate_loss(anchor, positive, negative)
+            gradients = tape.gradient(loss, model.trainable_variables)
+            optimizer.apply_gradients(zip(gradients, model.trainable_variables))
+            train_loss += loss.numpy()
         train_loss /= len(train_data)
         eval_loss, accuracy = evaluate_model(model, valid_data)
         history.append((train_loss, eval_loss, accuracy))
@@ -84,15 +80,14 @@ def evaluate_model(model, data):
     model.eval()
     total_loss = 0
     correct = 0
-    with torch.no_grad():
-        for batch in data:
-            anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-            total_loss += calculate_loss(anchor, positive, negative).item()
-            correct += count_accurate(anchor, positive, negative)
-    return total_loss / len(data), correct / len(data.dataset)
+    for batch in data:
+        anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+        total_loss += calculate_loss(anchor, positive, negative).numpy()
+        correct += count_accurate(anchor, positive, negative)
+    return total_loss / len(data), correct / len(data)
 
 def count_accurate(anchor, positive, negative):
-    return torch.sum((torch.sum(anchor * positive, dim=1) > torch.sum(anchor * negative, dim=1)).float()
+    return tf.reduce_sum(tf.cast(tf.reduce_sum(anchor * positive, axis=1) > tf.reduce_sum(anchor * negative, axis=1), tf.float32))
 
 def display_results(history):
     plt.figure(figsize=(10, 5))
@@ -112,21 +107,20 @@ def display_results(history):
     plt.show()
 
 def store_model(model, path):
-    torch.save(model.state_dict(), path)
+    model.save_weights(path)
     print(f'Model saved at {path}')
 
 def load_model(model, path):
-    model.load_state_dict(torch.load(path))
+    model.load_weights(path)
     print(f'Model loaded from {path}')
     return model
 
 def visualize_embeddings(model, data):
     model.eval()
     embeddings = []
-    with torch.no_grad():
-        for batch in data:
-            anchor, _, _ = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-            embeddings.append(anchor.numpy())
+    for batch in data:
+        anchor, _, _ = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+        embeddings.append(anchor.numpy())
     embeddings = np.concatenate(embeddings)
     fig = plt.figure(figsize=(10, 10))
     ax = fig.add_subplot(111, projection='3d')
@@ -149,12 +143,12 @@ def run_pipeline():
     mapping, snippet_files = fetch_data(dataset_path, snippets_dir)
     data = process_data(mapping, snippet_files)
     train_data, valid_data = np.array_split(np.array(data), 2)
-    train_loader = DataLoader(TripletDataset(train_data.tolist()), batch_size=32, shuffle=True)
-    valid_loader = DataLoader(TripletDataset(valid_data.tolist()), batch_size=32)
+    train_loader = tf.data.Dataset.from_tensor_slices(train_data.tolist()).batch(32).shuffle(len(train_data))
+    valid_loader = tf.data.Dataset.from_tensor_slices(valid_data.tolist()).batch(32)
     model = EmbeddingModel(vocab_size=len(train_loader.dataset.data.encoder.classes_) + 1, embed_dim=128)
     history = train_model(model, train_loader, valid_loader, epochs=5)
     display_results(history)
-    store_model(model, 'model.pth')
+    store_model(model, 'model.h5')
     visualize_embeddings(model, valid_loader)
 
 def add_feature():


### PR DESCRIPTION
This pull request is linked to issue #3860.
    The main significant changes in the updated code involve migrating from PyTorch to TensorFlow, which includes several key modifications:

1. Framework Migration: The code has been transitioned from PyTorch to TensorFlow. This includes replacing PyTorch-specific imports (`torch`, `torch.nn`, `torch.optim`, etc.) with TensorFlow equivalents (`tensorflow`, `tensorflow.keras`, etc.).

2. Dataset Handling: The `TripletDataset` class now inherits from `tf.data.Dataset` instead of PyTorch's `Dataset`. The `__getitem__` method now uses `tf.convert_to_tensor` instead of `torch.tensor`.

3. Model Definition: The `EmbeddingModel` class now inherits from `tf.keras.Model` instead of `nn.Module`. The network layers are defined using `tf.keras.layers` (e.g., `Dense`, `BatchNormalization`, `Dropout`). The `forward` method is renamed to `call` to align with TensorFlow's conventions.

4. Loss Calculation: The `calculate_loss` function now uses TensorFlow operations (`tf.reduce_mean`, `tf.maximum`, `tf.norm`) instead of PyTorch's equivalents.

5. Training Loop: The training loop has been adapted to TensorFlow's gradient tape mechanism. The optimizer is now `tf.keras.optimizers.Adam`, and the learning rate scheduler uses `tf.keras.optimizers.schedules.ExponentialDecay`.

6. Model Saving/Loading: The `store_model` and `load_model` functions now use TensorFlow's `save_weights` and `load_weights` methods instead of PyTorch's `state_dict` and `load_state_dict`.

7. DataLoader Replacement: The `DataLoader` from PyTorch has been replaced with TensorFlow's `tf.data.Dataset` API, specifically using `from_tensor_slices` and `batch` methods.

These changes align the code with TensorFlow's ecosystem, leveraging its specific functionalities and conventions while maintaining the original logic and structure of the pipeline.

Closes #3860