### PR TITLE
Bump numpy version from 1.26.10 to 1.26.11 for bug fixes and performance improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ tree-sitter-languages==1.11.0
 scikit-learn==1.4.4
 matplotlib==3.8.5
 tensorflow==2.16.4
-numpy==1.26.10
+numpy==1.26.11
 subprocess-run==1.0.51


### PR DESCRIPTION
This pull request is linked to issue #3864.
    The main significant change in this update is the version bump of `numpy` from `1.26.10` to `1.26.11`. This is a patch-level update, which typically includes bug fixes, performance improvements, or minor enhancements without introducing breaking changes. The rest of the dependencies remain unchanged, ensuring compatibility and stability across the existing codebase. This update aligns with maintaining up-to-date dependencies for security and performance benefits.

Closes #3864