### PR TITLE
Add save report to file functionality and output option for test reports

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -46,13 +46,18 @@ def create_test_report(affected_tests, test_results):
         })
     return report
 
+def save_report_to_file(report, file_path):
+    with open(file_path, "w") as file:
+        json.dump(report, file, indent=2)
+
 @click.command()
 @click.option('--repo', required=True, help='Repository path')
 @click.option('--commit', required=True, help='Commit hash')
 @click.option('--project', required=True, help='Project directory')
 @click.option('--run', is_flag=True, help='Run affected tests')
 @click.option('--report', is_flag=True, help='Generate test report')
-def analyze_repository(repo, commit, project, run, report):
+@click.option('--output', default="test_report.json", help='Output file for the test report')
+def analyze_repository(repo, commit, project, run, report, output):
     modified_methods = fetch_modified_methods(repo, commit)
     if not modified_methods:
         click.echo("No method changes found.")
@@ -74,6 +79,7 @@ def analyze_repository(repo, commit, project, run, report):
         if report:
             report_data = create_test_report(affected_tests, outcomes)
             click.echo(json.dumps(report_data, indent=2))
+            save_report_to_file(report_data, output)
 
 if __name__ == "__main__":
     analyze_repository()


### PR DESCRIPTION
This pull request is linked to issue #3916.
    The main significant changes in the updated code are as follows:

1. Added a new function `save_report_to_file(report, file_path)`:
   - This function takes a report dictionary and a file path as input.
   - It writes the report to the specified file in JSON format with indentation for readability.
   - This enhances the functionality by allowing the test report to be saved to a file for later reference or sharing.

2. Modified the `analyze_repository` function:
   - Added a new `--output` option to the Click command decorator.
   - This option allows the user to specify the output file path for the test report, with a default value of "test_report.json".
   - When the `--report` flag is used, the report data is now saved to the specified output file using the `save_report_to_file` function.
   - This change provides more flexibility and utility by enabling the report to be saved to a custom location.

These changes improve the overall functionality of the script by adding the ability to save the test report to a file, making it easier to share and analyze the results. The addition of the `--output` option also enhances user control over where the report is saved.

Closes #3916