### PR TITLE
Migrate implementation from TensorFlow to PyTorch with updated model, dataset, and training logic

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -2,62 +2,54 @@ import json
 import os
 import random
 import numpy as np
-import tensorflow as tf
-from tensorflow.keras import layers, models, optimizers
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import Dataset, DataLoader
 from sklearn.preprocessing import LabelEncoder
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 
 class DataProcessor:
-    """Processes and encodes text data for triplet loss training."""
     def __init__(self, data):
-        """Initializes the DataProcessor with the given data and fits a LabelEncoder."""
         self.data = data
         self.encoder = LabelEncoder().fit(self._gather_texts(data))
     
     def _gather_texts(self, data):
-        """Collects all anchor, positive, and negative texts from the data."""
         return [text for item in data for text in (item['anchor'], item['positive'], item['negative'])]
     
     def retrieve_data(self):
-        """Returns the processed data."""
         return self.data
 
-class TripletDataset(tf.data.Dataset):
-    """Custom TensorFlow Dataset for handling triplet data."""
+class TripletDataset(Dataset):
     def __init__(self, data):
-        """Initializes the dataset with processed data."""
         self.data = DataProcessor(data)
         self.samples = self.data.retrieve_data()
     
     def __len__(self):
-        """Returns the number of samples in the dataset."""
         return len(self.samples)
     
     def __getitem__(self, idx):
-        """Retrieves a single triplet sample by index."""
         item = self.samples[idx]
         return {
-            'anchor_seq': tf.convert_to_tensor(self.data.encoder.transform([item['anchor']])[0]),
-            'positive_seq': tf.convert_to_tensor(self.data.encoder.transform([item['positive']])[0]),
-            'negative_seq': tf.convert_to_tensor(self.data.encoder.transform([item['negative']])[0])
+            'anchor_seq': torch.tensor(self.data.encoder.transform([item['anchor']])[0],
+            'positive_seq': torch.tensor(self.data.encoder.transform([item['positive']])[0],
+            'negative_seq': torch.tensor(self.data.encoder.transform([item['negative']])[0])
         }
 
-class EmbeddingModel(models.Model):
-    """Neural network model for generating embeddings."""
+class EmbeddingModel(nn.Module):
     def __init__(self, vocab_size, embed_dim):
-        """Initializes the model with embedding and dense layers."""
         super(EmbeddingModel, self).__init__()
-        self.embedding = layers.Embedding(vocab_size, embed_dim)
-        self.network = models.Sequential([
-            layers.Dense(128, activation='relu'),
-            layers.BatchNormalization(),
-            layers.Dropout(0.2),
-            layers.Dense(128)
-        ])
+        self.embedding = nn.Embedding(vocab_size, embed_dim)
+        self.network = nn.Sequential(
+            nn.Linear(embed_dim, 128),
+            nn.ReLU(),
+            nn.BatchNorm1d(128),
+            nn.Dropout(0.2),
+            nn.Linear(128, 128)
+        )
     
-    def call(self, anchor, positive, negative):
-        """Generates embeddings for anchor, positive, and negative samples."""
+    def forward(self, anchor, positive, negative):
         return (
             self.network(self.embedding(anchor)),
             self.network(self.embedding(positive)),
@@ -65,47 +57,43 @@ class EmbeddingModel(models.Model):
         )
 
 def calculate_loss(anchor, positive, negative):
-    """Calculates the triplet loss for the given embeddings."""
-    return tf.reduce_mean(tf.maximum(0.2 + tf.norm(anchor - positive, axis=1) - tf.norm(anchor - negative, axis=1), 0))
+    return torch.mean(torch.clamp(0.2 + torch.norm(anchor - positive, dim=1) - torch.norm(anchor - negative, dim=1), min=0))
 
 def train_model(model, train_data, valid_data, epochs):
-    """Trains the model using the provided training and validation data."""
-    optimizer = optimizers.Adam(learning_rate=0.001)
-    scheduler = optimizers.schedules.ExponentialDecay(0.001, decay_steps=1000, decay_rate=0.1)
+    optimizer = optim.Adam(model.parameters(), lr=0.001)
+    scheduler = optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.1)
     history = []
     
     for _ in range(epochs):
         model.train()
         train_loss = 0
         for batch in train_data:
-            with tf.GradientTape() as tape:
-                anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-                loss = calculate_loss(anchor, positive, negative)
-            gradients = tape.gradient(loss, model.trainable_variables)
-            optimizer.apply_gradients(zip(gradients, model.trainable_variables))
-            train_loss += loss.numpy()
+            optimizer.zero_grad()
+            anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+            loss = calculate_loss(anchor, positive, negative)
+            loss.backward()
+            optimizer.step()
+            train_loss += loss.item()
         train_loss /= len(train_data)
         eval_loss, accuracy = evaluate_model(model, valid_data)
         history.append((train_loss, eval_loss, accuracy))
     return history
 
 def evaluate_model(model, data):
-    """Evaluates the model on the provided data."""
     model.eval()
     total_loss = 0
     correct = 0
-    for batch in data:
-        anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-        total_loss += calculate_loss(anchor, positive, negative).numpy()
-        correct += count_accurate(anchor, positive, negative)
+    with torch.no_grad():
+        for batch in data:
+            anchor, positive, negative = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+            total_loss += calculate_loss(anchor, positive, negative).item()
+            correct += count_accurate(anchor, positive, negative)
     return total_loss / len(data), correct / len(data)
 
 def count_accurate(anchor, positive, negative):
-    """Counts the number of accurate predictions based on cosine similarity."""
-    return tf.reduce_sum(tf.cast(tf.reduce_sum(anchor * positive, axis=1) > tf.reduce_sum(anchor * negative, axis=1), tf.float32))
+    return torch.sum((torch.sum(anchor * positive, dim=1) > torch.sum(anchor * negative, dim=1)).float()
 
 def display_results(history):
-    """Displays training and validation loss and accuracy over epochs."""
     plt.figure(figsize=(10, 5))
     plt.subplot(1, 2, 1)
     plt.plot([x[0] for x in history], label='Training Loss')
@@ -123,23 +111,21 @@ def display_results(history):
     plt.show()
 
 def store_model(model, path):
-    """Saves the model weights to the specified path."""
-    model.save_weights(path)
+    torch.save(model.state_dict(), path)
     print(f'Model saved at {path}')
 
 def load_model(model, path):
-    """Loads the model weights from the specified path."""
-    model.load_weights(path)
+    model.load_state_dict(torch.load(path))
     print(f'Model loaded from {path}')
     return model
 
 def visualize_embeddings(model, data):
-    """Visualizes the embeddings in a 3D scatter plot."""
     model.eval()
     embeddings = []
-    for batch in data:
-        anchor, _, _ = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
-        embeddings.append(anchor.numpy())
+    with torch.no_grad():
+        for batch in data:
+            anchor, _, _ = model(batch['anchor_seq'], batch['positive_seq'], batch['negative_seq'])
+            embeddings.append(anchor.numpy())
     embeddings = np.concatenate(embeddings)
     fig = plt.figure(figsize=(10, 10))
     ax = fig.add_subplot(111, projection='3d')
@@ -148,33 +134,29 @@ def visualize_embeddings(model, data):
     plt.show()
 
 def fetch_data(file_path, root_dir):
-    """Fetches and maps data from the specified file and directory."""
     data = json.load(open(file_path))
     mapping = {item['instance_id']: item['problem_statement'] for item in data}
     snippet_files = [(dir, os.path.join(root_dir, 'snippet.json')) for dir in os.listdir(root_dir) if os.path.isdir(os.path.join(root_dir, dir))]
     return mapping, snippet_files
 
 def process_data(mapping, snippet_files):
-    """Processes the data into a format suitable for triplet loss training."""
     return [{'anchor': mapping[os.path.basename(dir)], 'positive': bug_sample, 'negative': random.choice(non_bug_samples)}
             for dir, _ in snippet_files for bug_sample, non_bug_samples in [json.load(open(path)) for path in snippet_files]]
 
 def run_pipeline():
-    """Runs the entire pipeline from data fetching to model training and evaluation."""
     dataset_path, snippets_dir = 'datasets/SWE-bench_oracle.npy', 'datasets/10_10_after_fix_pytest'
     mapping, snippet_files = fetch_data(dataset_path, snippets_dir)
     data = process_data(mapping, snippet_files)
     train_data, valid_data = np.array_split(np.array(data), 2)
-    train_loader = tf.data.Dataset.from_tensor_slices(train_data.tolist()).batch(32).shuffle(len(train_data))
-    valid_loader = tf.data.Dataset.from_tensor_slices(valid_data.tolist()).batch(32)
+    train_loader = DataLoader(TripletDataset(train_data.tolist()), batch_size=32, shuffle=True)
+    valid_loader = DataLoader(TripletDataset(valid_data.tolist()), batch_size=32)
     model = EmbeddingModel(vocab_size=len(train_loader.dataset.data.encoder.classes_) + 1, embed_dim=128)
     history = train_model(model, train_loader, valid_loader, epochs=5)
     display_results(history)
-    store_model(model, 'model.h5')
+    store_model(model, 'model.pth')
     visualize_embeddings(model, valid_loader)
 
 def add_feature():
-    """Adds a new feature to the pipeline."""
     print("New feature added: Enhanced visualization with 3D embeddings.")
     return
 


### PR DESCRIPTION
This pull request is linked to issue #3936.
    The main significant changes in the updated code involve migrating the implementation from TensorFlow to PyTorch, which includes several key modifications:

1. Framework Migration: The code has been transitioned from TensorFlow to PyTorch. This includes replacing TensorFlow-specific imports (`tensorflow`, `tensorflow.keras`) with PyTorch equivalents (`torch`, `torch.nn`, `torch.optim`). The `EmbeddingModel` class now inherits from `nn.Module` instead of `models.Model`, and the layers are defined using PyTorch's `nn` module.

2. Dataset Handling: The `TripletDataset` class now inherits from `torch.utils.data.Dataset` instead of `tf.data.Dataset`. The `__getitem__` method now returns PyTorch tensors (`torch.tensor`) instead of TensorFlow tensors (`tf.convert_to_tensor`).

3. Model Training and Evaluation: The training loop has been updated to use PyTorch's `optim.Adam` for optimization and `optim.lr_scheduler.ExponentialLR` for learning rate scheduling. The `train_model` and `evaluate_model` functions now use PyTorch's `zero_grad()`, `backward()`, and `step()` methods for gradient updates. The loss calculation in `calculate_loss` uses `torch.clamp` instead of `tf.maximum`.

4. Model Saving and Loading: The `store_model` and `load_model` functions now use PyTorch's `state_dict()` and `load_state_dict()` methods for saving and loading model weights, replacing TensorFlow's `save_weights` and `load_weights`.

5. DataLoader Integration: The `DataLoader` class from PyTorch is used to create `train_loader` and `valid_loader`, replacing TensorFlow's `tf.data.Dataset.from_tensor_slices` and `batch` methods.

These changes align the code with PyTorch's ecosystem, leveraging its dynamic computation graph and more Pythonic API, while maintaining the core functionality of the original implementation.

Closes #3936