### PR TITLE
Add `add_embedding_histogram` function to visualize embedding distribution using matplotlib

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -116,6 +116,15 @@ def add_cosine_similarity(model, data):
     plt.title('Cosine Similarity Matrix')
     plt.show()
 
+def add_embedding_histogram(model, data):
+    embeds = model(torch.tensor(data, dtype=torch.long)).detach().numpy()
+    plt.figure(figsize=(8, 8))
+    plt.hist(embeds.flatten(), bins=50, color='blue', alpha=0.7)
+    plt.title('Embedding Value Distribution')
+    plt.xlabel('Embedding Value')
+    plt.ylabel('Frequency')
+    plt.show()
+
 if __name__ == "__main__":
     data, labels = generate_data(100)
     dataset = TripletDataset(data, labels, 5)
@@ -127,3 +136,4 @@ if __name__ == "__main__":
     evaluate_model(model, data, labels)
     visualize_embeddings(load_model(EmbeddingModel, "embedding_model.pth", 101, 10), *generate_data(100))
     add_cosine_similarity(model, data)
+    add_embedding_histogram(model, data)


### PR DESCRIPTION
This pull request is linked to issue #3978.
    The main significant change in this code is the addition of a new function `add_embedding_histogram` to visualize the distribution of embedding values. This function generates a histogram of the flattened embedding values, providing insights into the distribution and range of the learned embeddings. The histogram is plotted using `matplotlib`, with 50 bins, a blue color, and an alpha value of 0.7 for transparency. The title, x-label, and y-label are added to make the plot more informative. This function is called in the `__main__` block after evaluating the model and visualizing the embeddings, allowing users to analyze the embedding space more comprehensively. No other changes were made to the existing code structure or functionality.

Closes #3978