### PR TITLE
Fix `locate_test_methods` to correctly identify function calls within test functions

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -19,7 +19,7 @@ def locate_test_methods(project_path):
             ast_tree = parse(file.read(), filename=str(py_file))
         for node in ast_tree.body:
             if isinstance(node, FunctionDef) and "test" in node.name:
-                called_methods = [n.func.id for n in ast_tree.body if isinstance(n, Call) and isinstance(n.func, Name) and n in node.body]
+                called_methods = [n.func.id for n in node.body if isinstance(n, Call) and isinstance(n.func, Name)]
                 test_methods.append({"file": str(py_file), "name": node.name, "calls": called_methods})
     return test_methods
 
@@ -83,8 +83,3 @@ def analyze_repository(repo, commit, project, run, report, output):
 
 if __name__ == "__main__":
     analyze_repository()
-
-# TODO: Bug - The `locate_test_methods` function incorrectly identifies called methods. 
-# It currently iterates over `ast_tree.body` instead of `node.body`, which means it captures 
-# all function calls in the file, not just those within the test function. This leads to 
-# false positives when identifying affected tests.


### PR DESCRIPTION
This pull request is linked to issue #4004.
    The main significant change in this code is the fix for the bug in the `locate_test_methods` function. Previously, the function incorrectly identified called methods by iterating over `ast_tree.body` instead of `node.body`. This caused the function to capture all function calls in the file, not just those within the test function, leading to false positives when identifying affected tests.

In the updated code, the `called_methods` list is now generated by iterating over `node.body` instead of `ast_tree.body`. This ensures that only the function calls within the test function are captured, which is the intended behavior. This change improves the accuracy of identifying affected tests by ensuring that only relevant method calls are considered.

The rest of the code remains unchanged, including the logic for fetching modified methods, identifying affected tests, executing tests, and generating the test report. This fix addresses the core issue without requiring additional modifications to the overall structure or functionality of the script.

Closes #4004