### PR TITLE
Refactor function and variable names for improved clarity and readability

### DIFF
--- a/langchain_pipeline.py
+++ b/langchain_pipeline.py
@@ -7,59 +7,59 @@ from tool_library import Tool, create_agent
 from loguru import logger
 from functools import wraps
 
-def shuffle_and_split(items):
-    randomized = random.sample(items, len(items))
-    return [i for i in randomized if i['label'] == 1], [i for i in randomized if i['label'] == 0]
+def randomize_and_separate(items):
+    shuffled = random.sample(items, len(items))
+    return [item for item in shuffled if item['label'] == 1], [item for item in shuffled if item['label'] == 0]
 
-def process_items(items, counter):
-    return shuffle_and_split(items), counter + 1
+def handle_items(items, count):
+    return randomize_and_separate(items), count + 1
 
-def get_system_details(details):
-    return f"System environment details: {dict(os.environ)}\n{details}"
+def fetch_system_info(info):
+    return f"System environment details: {dict(os.environ)}\n{info}"
 
-def install_package(package):
-    output = run(["pip", "install", package], text=True, capture_output=True, check=True)
-    return output.stdout
+def add_package(pkg):
+    result = run(["pip", "install", pkg], text=True, capture_output=True, check=True)
+    return result.stdout
 
-def run_shell_command(command):
-    if not command:
+def execute_command(cmd):
+    if not cmd:
         return "", "No valid command provided."
-    output = run(command, shell=True, text=True, capture_output=True)
-    return output.stdout, output.stderr
+    result = run(cmd, shell=True, text=True, capture_output=True)
+    return result.stdout, result.stderr
 
-def setup_tools():
+def initialize_tools():
     return [
-        Tool(name="EnvViewer", func=get_system_details, description="Shows system environment details."),
-        Tool(name="PackageManager", func=install_package, description="Handles package installations.")
+        Tool(name="EnvViewer", func=fetch_system_info, description="Displays system environment details."),
+        Tool(name="PackageManager", func=add_package, description="Manages package installations.")
     ]
 
-def log_and_execute(command):
-    logger.info(f"Running command: {command}")
-    stdout, stderr = run_shell_command(command)
+def log_and_run(cmd):
+    logger.info(f"Executing command: {cmd}")
+    stdout, stderr = execute_command(cmd)
     if stderr:
         logger.error(f"Command failed: {stderr}")
         return False
     logger.success(f"Command succeeded: {stdout}")
     return True
 
-def retry_execution(agent, command, attempt, max_attempts):
+def retry_command(agent, cmd, attempt, max_attempts):
     if attempt >= max_attempts:
-        logger.error("Maximum retries reached. Aborting.")
+        logger.error("Max retries reached. Aborting.")
         return
     logger.info(f"Attempt {attempt + 1} of {max_attempts}")
-    if log_and_execute(command):
+    if log_and_run(cmd):
         logger.success("Command executed successfully!")
     else:
         agent.run("Verify environment variables and dependencies.")
         agent.run("Resolve issues by installing required packages.")
         time.sleep(5)
-        retry_execution(agent, command, attempt + 1, max_attempts)
+        retry_command(agent, cmd, attempt + 1, max_attempts)
 
-def execute_with_retry(command, max_attempts):
-    agent = create_agent(tools=setup_tools())
-    retry_execution(agent, command, 0, max_attempts)
+def execute_with_retries(cmd, max_attempts):
+    agent = create_agent(tools=initialize_tools())
+    retry_command(agent, cmd, 0, max_attempts)
 
-def time_execution(func):
+def measure_time(func):
     def wrapper(*args, **kwargs):
         start = time.time()
         result = func(*args, **kwargs)
@@ -67,42 +67,42 @@ def time_execution(func):
         return result
     return wrapper
 
-@time_execution
-def start_process(command, max_attempts):
-    logger.info("Initiating process...")
-    execute_with_retry(command, max_attempts)
+@measure_time
+def begin_process(cmd, max_attempts):
+    logger.info("Starting process...")
+    execute_with_retries(cmd, max_attempts)
 
-def log_command_history(command):
+def record_command(cmd):
     try:
         with open("command_log.txt", "a") as log_file:
-            log_file.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {command}\n")
+            log_file.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {cmd}\n")
     except Exception as e:
         logger.error(f"Failed to log command: {e}")
 
-def display_countdown(duration):
+def show_countdown(duration):
     if duration > 0:
-        logger.info(f"Remaining time: {duration} seconds")
+        logger.info(f"Time left: {duration} seconds")
         time.sleep(1)
-        display_countdown(duration - 1)
+        show_countdown(duration - 1)
     else:
-        logger.success("Countdown finished!")
+        logger.success("Countdown complete!")
 
-def execute_with_settings(command, max_attempts=5, countdown_duration=0):
-    log_command_history(command)
+def run_with_config(cmd, max_attempts=5, countdown_duration=0):
+    record_command(cmd)
     if countdown_duration > 0:
-        display_countdown(countdown_duration)
-    start_process(command, max_attempts)
+        show_countdown(countdown_duration)
+    begin_process(cmd, max_attempts)
 
-def backup_logs():
+def save_logs():
     try:
         with open("command_log.txt", "r") as log_file:
             logs = log_file.read()
         with open(f"command_log_backup_{time.strftime('%Y%m%d%H%M%S')}.txt", "w") as backup_file:
             backup_file.write(logs)
-        logger.success("Backup completed successfully!")
+        logger.success("Backup successful!")
     except Exception as e:
-        logger.error(f"Backup error: {e}")
+        logger.error(f"Backup failed: {e}")
 
 if __name__ == "__main__":
-    typer.run(execute_with_settings)
-    backup_logs()
+    typer.run(run_with_config)
+    save_logs()


### PR DESCRIPTION
This pull request is linked to issue #4030.
    The main significant changes in the updated code are primarily focused on renaming functions and variables for improved clarity and readability, without altering the core functionality. Here's a breakdown of the key changes:

1. Function and Variable Renaming:
   - `shuffle_and_split` renamed to `randomize_and_separate` to better describe its purpose.
   - `process_items` renamed to `handle_items` for simplicity.
   - `get_system_details` renamed to `fetch_system_info` for better readability.
   - `install_package` renamed to `add_package` for consistency.
   - `run_shell_command` renamed to `execute_command` for clarity.
   - `setup_tools` renamed to `initialize_tools` to better reflect its purpose.
   - `log_and_execute` renamed to `log_and_run` for brevity.
   - `retry_execution` renamed to `retry_command` for consistency.
   - `execute_with_retry` renamed to `execute_with_retries` for grammatical correctness.
   - `time_execution` renamed to `measure_time` for better clarity.
   - `start_process` renamed to `begin_process` for simplicity.
   - `log_command_history` renamed to `record_command` for better readability.
   - `display_countdown` renamed to `show_countdown` for brevity.
   - `execute_with_settings` renamed to `run_with_config` for better clarity.
   - `backup_logs` renamed to `save_logs` for simplicity.

2. Variable Renaming:
   - `items` and `counter` in `process_items` renamed to `items` and `count` in `handle_items` for consistency.
   - `details` in `get_system_details` renamed to `info` in `fetch_system_info` for better readability.
   - `package` in `install_package` renamed to `pkg` in `add_package` for brevity.
   - `command` in `run_shell_command` renamed to `cmd` in `execute_command` for consistency.
   - `command` in `log_and_execute` renamed to `cmd` in `log_and_run` for consistency.
   - `command` in `retry_execution` renamed to `cmd` in `retry_command` for consistency.
   - `command` in `execute_with_retry` renamed to `cmd` in `execute_with_retries` for consistency.
   - `command` in `start_process` renamed to `cmd` in `begin_process` for consistency.
   - `command` in `log_command_history` renamed to `cmd` in `record_command` for consistency.
   - `command` in `execute_with_settings` renamed to `cmd` in `run_with_config` for consistency.

These changes enhance code readability and maintainability without altering the underlying logic or functionality.

Closes #4030