### PR TITLE
Remove redundant docstrings to streamline codebase and improve readability for experienced developers

### DIFF
--- a/langchain_pipeline.py
+++ b/langchain_pipeline.py
@@ -8,93 +8,32 @@ from loguru import logger
 from functools import wraps
 
 def shuffle_and_split(items):
-    """
-    Shuffles the list of items and splits them into two lists based on their 'label' value.
-    
-    Args:
-        items (list): A list of dictionaries, each containing a 'label' key.
-    
-    Returns:
-        tuple: Two lists, one containing items with label 1, the other with label 0.
-    """
     randomized = random.sample(items, len(items))
     return [i for i in randomized if i['label'] == 1], [i for i in randomized if i['label'] == 0]
 
 def process_items(items, counter):
-    """
-    Processes items by shuffling and splitting them, and increments the counter.
-    
-    Args:
-        items (list): A list of items to process.
-        counter (int): A counter to increment.
-    
-    Returns:
-        tuple: A tuple containing the shuffled and split items, and the incremented counter.
-    """
     return shuffle_and_split(items), counter + 1
 
 def get_system_details(info):
-    """
-    Returns a string containing system environment details and additional info.
-    
-    Args:
-        info (str): Additional information to include in the output.
-    
-    Returns:
-        str: A string containing system environment details and the provided info.
-    """
     return f"System environment: {dict(os.environ)}\n{info}"
 
 def install_package(pkg):
-    """
-    Installs a Python package using pip.
-    
-    Args:
-        pkg (str): The name of the package to install.
-    
-    Returns:
-        str: The output of the pip install command.
-    """
     output = run(["pip", "install", pkg], text=True, capture_output=True, check=True)
     return output.stdout
 
 def run_shell_command(cmd):
-    """
-    Executes a shell command and returns the output.
-    
-    Args:
-        cmd (str): The shell command to execute.
-    
-    Returns:
-        tuple: A tuple containing the stdout and stderr of the command.
-    """
     if not cmd:
         return "", "No command provided."
     output = run(cmd, shell=True, text=True, capture_output=True)
     return output.stdout, output.stderr
 
 def setup_tools():
-    """
-    Sets up and returns a list of tools for the agent to use.
-    
-    Returns:
-        list: A list of Tool objects.
-    """
     return [
         Tool(name="EnvInspector", func=get_system_details, description="Shows system environment details."),
         Tool(name="PkgInstaller", func=install_package, description="Handles package installations.")
     ]
 
 def log_execution(cmd):
-    """
-    Logs and executes a shell command, handling errors if they occur.
-    
-    Args:
-        cmd (str): The shell command to execute.
-    
-    Returns:
-        bool: True if the command executed successfully, False otherwise.
-    """
     logger.info(f"Running command: {cmd}")
     stdout, stderr = run_shell_command(cmd)
     if stderr:
@@ -104,15 +43,6 @@ def log_execution(cmd):
     return True
 
 def retry_execution(agent, cmd, attempt, max_attempts):
-    """
-    Retries executing a shell command if it fails, up to a maximum number of attempts.
-    
-    Args:
-        agent: The agent responsible for handling retries.
-        cmd (str): The shell command to execute.
-        attempt (int): The current attempt number.
-        max_attempts (int): The maximum number of retry attempts.
-    """
     if attempt >= max_attempts:
         logger.error("Max retries exceeded. Stopping.")
         return
@@ -126,26 +56,10 @@ def retry_execution(agent, cmd, attempt, max_attempts):
         retry_execution(agent, cmd, attempt + 1, max_attempts)
 
 def execute_with_retry(cmd, max_attempts):
-    """
-    Executes a shell command with retry logic.
-    
-    Args:
-        cmd (str): The shell command to execute.
-        max_attempts (int): The maximum number of retry attempts.
-    """
     agent = create_agent(tools=setup_tools())
     retry_execution(agent, cmd, 0, max_attempts)
 
 def time_execution(func):
-    """
-    A decorator that logs the execution time of a function.
-    
-    Args:
-        func: The function to be timed.
-    
-    Returns:
-        function: The wrapped function with timing logic.
-    """
     @wraps(func)
     def wrapper(*args, **kwargs):
         start = time.time()
@@ -156,23 +70,10 @@ def time_execution(func):
 
 @time_execution
 def start_process(cmd, max_attempts):
-    """
-    Initiates a process with retry logic and logs the start and end of the process.
-    
-    Args:
-        cmd (str): The shell command to execute.
-        max_attempts (int): The maximum number of retry attempts.
-    """
     logger.info("Process initiated...")
     execute_with_retry(cmd, max_attempts)
 
 def log_command(cmd):
-    """
-    Logs a command to a file with a timestamp.
-    
-    Args:
-        cmd (str): The command to log.
-    """
     try:
         with open("command_log.txt", "a") as log_file:
             log_file.write(f"{time.strftime('%Y-%m-%d %H:%M:%S')} - {cmd}\n")
@@ -180,12 +81,6 @@ def log_command(cmd):
         logger.error(f"Logging failed: {e}")
 
 def display_countdown(duration):
-    """
-    Displays a countdown in the logs for the specified duration.
-    
-    Args:
-        duration (int): The duration of the countdown in seconds.
-    """
     if duration > 0:
         logger.info(f"Remaining time: {duration} seconds")
         time.sleep(1)
@@ -194,23 +89,12 @@ def display_countdown(duration):
         logger.success("Countdown finished!")
 
 def execute_with_settings(cmd, max_attempts=5, countdown_duration=0):
-    """
-    Executes a command with specified settings, including retry attempts and a countdown.
-    
-    Args:
-        cmd (str): The shell command to execute.
-        max_attempts (int): The maximum number of retry attempts.
-        countdown_duration (int): The duration of the countdown before execution.
-    """
     log_command(cmd)
     if countdown_duration > 0:
         display_countdown(countdown_duration)
     start_process(cmd, max_attempts)
 
 def backup_logs():
-    """
-    Backs up the command log to a new file with a timestamp.
-    """
     try:
         with open("command_log.txt", "r") as log_file:
             logs = log_file.read()


### PR DESCRIPTION
This pull request is linked to issue #4102.
    The main significant changes in the updated code are as follows:

1. **Removed Redundant Docstrings**: The docstrings for functions like `shuffle_and_split`, `process_items`, `get_system_details`, `install_package`, `run_shell_command`, `setup_tools`, `log_execution`, `retry_execution`, `execute_with_retry`, `time_execution`, `start_process`, `log_command`, `display_countdown`, `execute_with_settings`, and `backup_logs` have been removed. These docstrings were previously providing detailed descriptions of the functions, their arguments, and return values. The removal simplifies the code, assuming the functionality is well-understood by the team or documented elsewhere.

2. **Code Structure and Readability**: The overall structure of the code remains unchanged, but the removal of docstrings makes the code more concise. This could improve readability for developers familiar with the codebase, but may reduce clarity for new contributors or those less familiar with the functions' purposes.

3. **Functionality Unchanged**: Despite the removal of docstrings, the core functionality of the code remains intact. All functions perform the same operations as before, such as shuffling and splitting items, processing commands, handling retries, logging, and backing up logs.

4. **No New Features or Bug Fixes**: The update does not introduce any new features or address any bugs. It is purely a refactoring effort focused on reducing verbosity by removing documentation.

These changes are primarily aimed at streamlining the codebase, potentially making it easier to maintain for experienced developers, but at the cost of reduced inline documentation.

Closes #4102