### PR TITLE
Refactor function and variable names for improved readability and maintainability

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -8,28 +8,28 @@ from functools import reduce
 
 PYTHON_CMD = "python3"
 
-def get_git_diff(repo_path, commit_id):
+def fetch_diff(repo_path, commit_id):
     os.chdir(repo_path)
     return subprocess.check_output(["git", "diff", commit_id, "--", "*.py"], text=True)
 
-def extract_methods_from_diff(diff_output):
+def parse_diff(diff_output):
     return {func.split('(')[0].strip('+') for line in diff_output.split('\n') if line.startswith('@@') and len(line.split()) > 3 and '(' in (func := line.split()[3])}
 
-def find_test_functions(py_file):
+def scan_tests(py_file):
     return [{"file": str(py_file), "name": node.name, "calls": [n.func.id for n in node.body if isinstance(n, Call) and isinstance(n.func, Name)]}
             for node in parse(py_file.read_text(), filename=str(py_file)).body if isinstance(node, FunctionDef) and "test" in node.name]
 
-def gather_tests(project_path):
-    return reduce(lambda acc, py_file: acc + find_test_functions(py_file), Path(project_path).rglob("*.py"), [])
+def collect_tests(project_path):
+    return reduce(lambda acc, py_file: acc + scan_tests(py_file), Path(project_path).rglob("*.py"), [])
 
-def filter_affected_tests(tests, modified_methods):
+def filter_tests(tests, modified_methods):
     return [{"file": test["file"], "name": test["name"], "called": call} for test in tests for call in test["calls"] if call in modified_methods]
 
-def run_pytest(test_file, test_name):
+def execute_test(test_file, test_name):
     result = subprocess.run([PYTHON_CMD, "-m", "pytest", f"{test_file}::{test_name}"], capture_output=True, text=True)
     return result.returncode == 0
 
-def generate_report_data(affected_tests, outcomes):
+def create_report(affected_tests, outcomes):
     return {
         "total": len(affected_tests),
         "passed": sum(outcomes),
@@ -37,7 +37,7 @@ def generate_report_data(affected_tests, outcomes):
         "info": [{"name": test["name"], "file": test["file"], "result": "passed" if result else "failed"} for test, result in zip(affected_tests, outcomes)]
     }
 
-def write_report(report_data, output_file):
+def save_report(report_data, output_file):
     with open(output_file, "w") as file:
         json.dump(report_data, file, indent=2)
 
@@ -49,25 +49,25 @@ def write_report(report_data, output_file):
 @click.option('--report', is_flag=True, help='Create a test report')
 @click.option('--output', default="test_report.json", help='Destination file for the test report')
 def main(repo, commit, project, run, report, output):
-    diff_output = get_git_diff(repo, commit)
-    modified_methods = extract_methods_from_diff(diff_output)
+    diff_output = fetch_diff(repo, commit)
+    modified_methods = parse_diff(diff_output)
     if not modified_methods:
         click.echo("No changes detected in methods.")
         return
-    tests = gather_tests(project)
-    affected_tests = filter_affected_tests(tests, modified_methods)
+    tests = collect_tests(project)
+    affected_tests = filter_tests(tests, modified_methods)
     click.echo(json.dumps(affected_tests, indent=2))
     
     if run:
-        outcomes = [run_pytest(test['file'], test['name']) for test in affected_tests]
+        outcomes = [execute_test(test['file'], test['name']) for test in affected_tests]
         for test, success in zip(affected_tests, outcomes):
             click.echo(f"Executing test: {test['name']} in {test['file']}")
             click.echo(f"Test {test['name']} {'passed' if success else 'failed'}.")
         
         if report:
-            report_data = generate_report_data(affected_tests, outcomes)
+            report_data = create_report(affected_tests, outcomes)
             click.echo(json.dumps(report_data, indent=2))
-            write_report(report_data, output)
+            save_report(report_data, output)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request is linked to issue #4104.
    The main changes in this code are primarily focused on renaming functions and variables to improve readability and maintainability, without altering the core functionality. Here's a breakdown of the significant changes:

1. Function Renaming:
   - `get_git_diff` is renamed to `fetch_diff` to better reflect its purpose of retrieving Git diff output.
   - `extract_methods_from_diff` is renamed to `parse_diff` for clarity, as it parses the diff output to extract modified methods.
   - `find_test_functions` is renamed to `scan_tests` to make it more concise and descriptive.
   - `gather_tests` is renamed to `collect_tests` for better readability.
   - `filter_affected_tests` is renamed to `filter_tests` to simplify the function name while retaining its purpose.
   - `run_pytest` is renamed to `execute_test` to make it more generic and clear.
   - `generate_report_data` is renamed to `create_report` for brevity.
   - `write_report` is renamed to `save_report` to better describe the action of saving the report to a file.

2. Variable Naming:
   - The variable names within the functions remain largely unchanged, as they were already descriptive and clear.

3. Logic and Functionality:
   - The core logic of the code remains unchanged. The functions still perform the same operations, such as fetching Git diffs, parsing them, scanning for test functions, filtering affected tests, executing tests, and generating/saving reports.

These changes are aimed at improving the code's readability and making it easier for developers to understand and maintain the codebase. The functionality remains consistent with the original implementation.

Closes #4104