### PR TITLE
Refactor function and variable names for improved clarity and readability

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -8,28 +8,28 @@ from functools import reduce
 
 PYTHON_CMD = "python3"
 
-def get_git_changes(repo_path, commit_id):
+def fetch_git_changes(repo_path, commit_id):
     os.chdir(repo_path)
     return subprocess.check_output(["git", "diff", commit_id, "--", "*.py"], text=True)
 
-def extract_modified_functions(diff_text):
+def identify_changed_functions(diff_text):
     return {func.split('(')[0].strip('+') for line in diff_text.split('\n') if line.startswith('@@') and len(line.split()) > 3 and '(' in (func := line.split()[3])}
 
-def analyze_python_file(file_path):
+def inspect_python_file(file_path):
     return [{"file": str(file_path), "name": node.name, "calls": [n.func.id for n in node.body if isinstance(n, Call) and isinstance(n.func, Name)]}
             for node in parse(file_path.read_text(), filename=str(file_path)).body if isinstance(node, FunctionDef) and "test" in node.name]
 
-def gather_all_tests(directory):
-    return reduce(lambda acc, file: acc + analyze_python_file(file), Path(directory).rglob("*.py"), [])
+def collect_all_tests(directory):
+    return reduce(lambda acc, file: acc + inspect_python_file(file), Path(directory).rglob("*.py"), [])
 
-def find_affected_tests(test_list, modified_functions):
+def detect_impacted_tests(test_list, modified_functions):
     return [{"file": test["file"], "name": test["name"], "called": call} for test in test_list for call in test["calls"] if call in modified_functions]
 
-def run_single_test(test_path, test_name):
+def execute_test(test_path, test_name):
     result = subprocess.run([PYTHON_CMD, "-m", "pytest", f"{test_path}::{test_name}"], capture_output=True, text=True)
     return result.returncode == 0
 
-def generate_test_results(test_list, results):
+def compile_test_results(test_list, results):
     return {
         "total": len(test_list),
         "passed": sum(results),
@@ -37,7 +37,7 @@ def generate_test_results(test_list, results):
         "info": [{"name": test["name"], "file": test["file"], "result": "passed" if result else "failed"} for test, result in zip(test_list, results)]
     }
 
-def write_results_to_file(data, file_name):
+def save_results(data, file_name):
     with open(file_name, "w") as file:
         json.dump(data, file, indent=2)
 
@@ -48,26 +48,26 @@ def write_results_to_file(data, file_name):
 @click.option('--run', is_flag=True, help='Execute affected tests')
 @click.option('--report', is_flag=True, help='Create a test report')
 @click.option('--output', default="test_report.json", help='Destination file for the test report')
-def execute(repo, commit, project, run, report, output):
-    changes = get_git_changes(repo, commit)
-    functions = extract_modified_functions(changes)
+def main(repo, commit, project, run, report, output):
+    changes = fetch_git_changes(repo, commit)
+    functions = identify_changed_functions(changes)
     if not functions:
         click.echo("No changes detected in methods.")
         return
-    all_tests = gather_all_tests(project)
-    affected = find_affected_tests(all_tests, functions)
+    all_tests = collect_all_tests(project)
+    affected = detect_impacted_tests(all_tests, functions)
     click.echo(json.dumps(affected, indent=2))
     
     if run:
-        results = [run_single_test(test['file'], test['name']) for test in affected]
+        results = [execute_test(test['file'], test['name']) for test in affected]
         for test, success in zip(affected, results):
             click.echo(f"Executing test: {test['name']} in {test['file']}")
             click.echo(f"Test {test['name']} {'passed' if success else 'failed'}.")
         
         if report:
-            report_data = generate_test_results(affected, results)
+            report_data = compile_test_results(affected, results)
             click.echo(json.dumps(report_data, indent=2))
-            write_results_to_file(report_data, output)
+            save_results(report_data, output)
 
 if __name__ == "__main__":
-    execute()
+    main()


### PR DESCRIPTION
This pull request is linked to issue #4130.
    The main changes in this code are primarily focused on renaming functions and variables to improve clarity and readability, without altering the core functionality. Here's a breakdown of the significant changes:

1. Function Renaming:
   - `get_git_changes` is now `fetch_git_changes` to better reflect its purpose of retrieving Git changes.
   - `extract_modified_functions` is renamed to `identify_changed_functions` for clearer intent.
   - `analyze_python_file` is now `inspect_python_file` to better describe the action of inspecting a Python file.
   - `gather_all_tests` is renamed to `collect_all_tests` for consistency in terminology.
   - `find_affected_tests` is now `detect_impacted_tests` to better convey the action of detecting impacted tests.
   - `run_single_test` is renamed to `execute_test` for brevity and clarity.
   - `generate_test_results` is now `compile_test_results` to better describe the action of compiling results.
   - `write_results_to_file` is renamed to `save_results` for simplicity.

2. Variable Renaming:
   - The `execute` function is renamed to `main` to align with common Python conventions for the entry point of a script.

3. No Functional Changes:
   - The logic and flow of the code remain unchanged. The renaming is purely for improving readability and maintainability, ensuring that the function names more accurately describe their actions.

These changes are aimed at making the codebase more intuitive and easier to understand for developers, especially in a large project with many contributors. The renaming aligns with common Python naming conventions and improves the overall clarity of the code.

Closes #4130