### PR TITLE
Refactor function and variable names for improved clarity and readability

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -8,28 +8,28 @@ from functools import reduce
 
 PYTHON_CMD = "python3"
 
-def fetch_git_changes(repo_path, commit_id):
+def get_git_diff(repo_path, commit_id):
     os.chdir(repo_path)
     return subprocess.check_output(["git", "diff", commit_id, "--", "*.py"], text=True)
 
-def identify_changed_functions(diff_text):
+def extract_modified_functions(diff_text):
     return {func.split('(')[0].strip('+') for line in diff_text.split('\n') if line.startswith('@@') and len(line.split()) > 3 and '(' in (func := line.split()[3])}
 
-def inspect_python_file(file_path):
+def analyze_python_file(file_path):
     return [{"file": str(file_path), "name": node.name, "calls": [n.func.id for n in node.body if isinstance(n, Call) and isinstance(n.func, Name)]}
             for node in parse(file_path.read_text(), filename=str(file_path)).body if isinstance(node, FunctionDef) and "test" in node.name]
 
-def collect_all_tests(directory):
-    return reduce(lambda acc, file: acc + inspect_python_file(file), Path(directory).rglob("*.py"), [])
+def gather_tests(directory):
+    return reduce(lambda acc, file: acc + analyze_python_file(file), Path(directory).rglob("*.py"), [])
 
-def detect_impacted_tests(test_list, modified_functions):
+def find_affected_tests(test_list, modified_functions):
     return [{"file": test["file"], "name": test["name"], "called": call} for test in test_list for call in test["calls"] if call in modified_functions]
 
-def execute_test(test_path, test_name):
+def run_test(test_path, test_name):
     result = subprocess.run([PYTHON_CMD, "-m", "pytest", f"{test_path}::{test_name}"], capture_output=True, text=True)
     return result.returncode == 0
 
-def compile_test_results(test_list, results):
+def generate_report(test_list, results):
     return {
         "total": len(test_list),
         "passed": sum(results),
@@ -37,7 +37,7 @@ def compile_test_results(test_list, results):
         "info": [{"name": test["name"], "file": test["file"], "result": "passed" if result else "failed"} for test, result in zip(test_list, results)]
     }
 
-def save_results(data, file_name):
+def save_report(data, file_name):
     with open(file_name, "w") as file:
         json.dump(data, file, indent=2)
 
@@ -49,25 +49,25 @@ def save_results(data, file_name):
 @click.option('--report', is_flag=True, help='Create a test report')
 @click.option('--output', default="test_report.json", help='Destination file for the test report')
 def main(repo, commit, project, run, report, output):
-    changes = fetch_git_changes(repo, commit)
-    functions = identify_changed_functions(changes)
-    if not functions:
+    diff = get_git_diff(repo, commit)
+    modified_funcs = extract_modified_functions(diff)
+    if not modified_funcs:
         click.echo("No changes detected in methods.")
         return
-    all_tests = collect_all_tests(project)
-    affected = detect_impacted_tests(all_tests, functions)
-    click.echo(json.dumps(affected, indent=2))
+    tests = gather_tests(project)
+    impacted_tests = find_affected_tests(tests, modified_funcs)
+    click.echo(json.dumps(impacted_tests, indent=2))
     
     if run:
-        results = [execute_test(test['file'], test['name']) for test in affected]
-        for test, success in zip(affected, results):
+        test_results = [run_test(test['file'], test['name']) for test in impacted_tests]
+        for test, success in zip(impacted_tests, test_results):
             click.echo(f"Executing test: {test['name']} in {test['file']}")
             click.echo(f"Test {test['name']} {'passed' if success else 'failed'}.")
         
         if report:
-            report_data = compile_test_results(affected, results)
+            report_data = generate_report(impacted_tests, test_results)
             click.echo(json.dumps(report_data, indent=2))
-            save_results(report_data, output)
+            save_report(report_data, output)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request is linked to issue #4138.
    The main changes in this code are primarily focused on renaming functions and variables to improve clarity and readability, without altering the core functionality. Here's a breakdown of the significant changes:

1. Function Renaming:
   - `fetch_git_changes` is renamed to `get_git_diff` to better reflect its purpose of retrieving Git diff output.
   - `identify_changed_functions` is renamed to `extract_modified_functions` for clarity, as it extracts modified function names from the Git diff.
   - `inspect_python_file` is renamed to `analyze_python_file` to better describe its role in analyzing Python files for test functions.
   - `collect_all_tests` is renamed to `gather_tests` for brevity and clarity.
   - `detect_impacted_tests` is renamed to `find_affected_tests` to make the function name more intuitive.
   - `execute_test` is renamed to `run_test` for simplicity.
   - `compile_test_results` is renamed to `generate_report` to better describe its purpose of generating a test report.
   - `save_results` is renamed to `save_report` to align with the new naming convention.

2. Variable Renaming:
   - `changes` is renamed to `diff` in the `main` function to reflect that it holds the Git diff output.
   - `functions` is renamed to `modified_funcs` to better indicate that it contains modified function names.
   - `all_tests` is renamed to `tests` for brevity.
   - `affected` is renamed to `impacted_tests` to better describe the affected tests.
   - `results` is renamed to `test_results` in the `main` function to clarify that it holds the results of test executions.

These changes are purely cosmetic and aim to improve code readability and maintainability without altering the underlying logic or functionality.

Closes #4138