### PR TITLE
Add test coverage report generation with --coverage CLI flag

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -41,14 +41,19 @@ def store_summary(summary, filename):
     with open(filename, "w") as file:
         json.dump(summary, file, indent=2)
 
+def generate_test_coverage_report(test_dir):
+    subprocess.run([PYTHON_EXEC, "-m", "coverage", "run", "--source", test_dir, "-m", "pytest", test_dir])
+    subprocess.run([PYTHON_EXEC, "-m", "coverage", "html", "-d", "coverage_report"])
+
 @click.command()
 @click.option('--repo', required=True, help='Repository directory')
 @click.option('--commit', required=True, help='Commit hash')
 @click.option('--project', required=True, help='Project directory')
 @click.option('--run', is_flag=True, help='Run impacted tests')
 @click.option('--report', is_flag=True, help='Generate test summary')
+@click.option('--coverage', is_flag=True, help='Generate test coverage report')
 @click.option('--output', default="test_summary.json", help='Output file for test summary')
-def cli(repo, commit, project, run, report, output):
+def cli(repo, commit, project, run, report, coverage, output):
     changes = fetch_git_changes(repo, commit)
     altered_funcs = identify_changed_functions(changes)
     if not altered_funcs:
@@ -68,6 +73,9 @@ def cli(repo, commit, project, run, report, output):
             summary = create_test_summary(affected_tests, results)
             click.echo(json.dumps(summary, indent=2))
             store_summary(summary, output)
+    
+    if coverage:
+        generate_test_coverage_report(project)
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
This pull request is linked to issue #4168.
    The main significant change in this update is the addition of a new feature to generate a test coverage report. This is achieved by introducing a new function `generate_test_coverage_report(test_dir)` which runs the test suite with coverage using the `coverage` module and generates an HTML coverage report. The function is called when the `--coverage` flag is provided in the CLI.

Additionally, a new CLI option `--coverage` has been added to the `cli()` function. When this flag is set, the `generate_test_coverage_report(project)` function is invoked, which runs the tests in the specified project directory with coverage tracking and outputs the coverage report to a directory named `coverage_report`.

This enhancement allows users to not only identify and run impacted tests but also to measure the test coverage of their codebase, providing more insights into the effectiveness of their tests. The coverage report is generated in HTML format, making it easier to visualize which parts of the code are covered by tests and which are not.

The rest of the code remains unchanged, maintaining the existing functionality of detecting changed functions, identifying impacted tests, running those tests, and generating a test summary report.

Closes #4168