### PR TITLE
Refactor functions into lambda expressions for conciseness and functional programming style

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -8,42 +8,47 @@ from functools import reduce
 
 PYTHON_EXEC = "python3"
 
-def fetch_git_changes(repo_dir, commit_hash):
-    os.chdir(repo_dir)
-    return subprocess.check_output(["git", "diff", commit_hash, "--", "*.py"], text=True)
+fetch_git_changes = lambda repo_dir, commit_hash: (
+    os.chdir(repo_dir),
+    subprocess.check_output(["git", "diff", commit_hash, "--", "*.py"], text=True)
+)[1]
 
-def identify_changed_functions(diff_content):
-    return {func.split('(')[0].strip('+') for line in diff_content.split('\n') if line.startswith('@@') and len(line.split()) > 3 and '(' in (func := line.split()[3])}
+identify_changed_functions = lambda diff_content: {
+    func.split('(')[0].strip('+') for line in diff_content.split('\n') 
+    if line.startswith('@@') and len(line.split()) > 3 and '(' in (func := line.split()[3])
+}
 
-def inspect_python_script(script_path):
-    return [{"file": str(script_path), "name": node.name, "calls": [n.func.id for n in node.body if isinstance(n, Call) and isinstance(n.func, Name)]}
-            for node in parse(script_path.read_text(), filename=str(script_path)).body if isinstance(node, FunctionDef) and "test" in node.name]
+inspect_python_script = lambda script_path: [
+    {"file": str(script_path), "name": node.name, "calls": [n.func.id for n in node.body if isinstance(n, Call) and isinstance(n.func, Name)]}
+    for node in parse(script_path.read_text(), filename=str(script_path)).body if isinstance(node, FunctionDef) and "test" in node.name
+]
 
-def collect_tests(test_dir):
-    return reduce(lambda acc, file: acc + inspect_python_script(file), Path(test_dir).rglob("*.py"), [])
+collect_tests = lambda test_dir: reduce(lambda acc, file: acc + inspect_python_script(file), Path(test_dir).rglob("*.py"), [])
 
-def determine_impacted_tests(tests, changed_funcs):
-    return [{"file": test["file"], "name": test["name"], "called": call} for test in tests for call in test["calls"] if call in changed_funcs]
+determine_impacted_tests = lambda tests, changed_funcs: [
+    {"file": test["file"], "name": test["name"], "called": call} 
+    for test in tests for call in test["calls"] if call in changed_funcs
+]
 
-def execute_test(test_file, test_func):
-    result = subprocess.run([PYTHON_EXEC, "-m", "pytest", f"{test_file}::{test_func}"], capture_output=True, text=True)
-    return result.returncode == 0
+execute_test = lambda test_file, test_func: (
+    lambda result: result.returncode == 0
+)(subprocess.run([PYTHON_EXEC, "-m", "pytest", f"{test_file}::{test_func}"], capture_output=True, text=True))
 
-def create_test_summary(test_data, outcomes):
-    return {
-        "total": len(test_data),
-        "passed": sum(outcomes),
-        "failed": len(test_data) - sum(outcomes),
-        "info": [{"name": test["name"], "file": test["file"], "result": "passed" if result else "failed"} for test, result in zip(test_data, outcomes)]
-    }
+create_test_summary = lambda test_data, outcomes: {
+    "total": len(test_data),
+    "passed": sum(outcomes),
+    "failed": len(test_data) - sum(outcomes),
+    "info": [{"name": test["name"], "file": test["file"], "result": "passed" if result else "failed"} for test, result in zip(test_data, outcomes)]
+}
 
-def store_summary(summary, filename):
-    with open(filename, "w") as file:
-        json.dump(summary, file, indent=2)
+store_summary = lambda summary, filename: (
+    lambda file: json.dump(summary, file, indent=2)
+)(open(filename, "w"))
 
-def generate_test_coverage_report(test_dir):
-    subprocess.run([PYTHON_EXEC, "-m", "coverage", "run", "--source", test_dir, "-m", "pytest", test_dir])
+generate_test_coverage_report = lambda test_dir: (
+    subprocess.run([PYTHON_EXEC, "-m", "coverage", "run", "--source", test_dir, "-m", "pytest", test_dir]),
     subprocess.run([PYTHON_EXEC, "-m", "coverage", "html", "-d", "coverage_report"])
+)
 
 @click.command()
 @click.option('--repo', required=True, help='Repository directory')


### PR DESCRIPTION
This pull request is linked to issue #4182.
    The main changes in this code involve refactoring several functions into lambda expressions for conciseness and functional programming style. Here's a breakdown of the significant changes:

1. fetch_git_changes: Converted to a lambda that uses tuple unpacking to return the git diff output after changing the directory. This reduces the function to a single line while maintaining the same functionality.

2. identify_changed_functions: Refactored into a lambda, keeping the logic intact but making it more compact. The set comprehension remains the same, but the function definition is now a single line.

3. inspect_python_script: Transformed into a lambda that returns a list comprehension. The logic for parsing Python scripts and extracting function details is unchanged, but the function is now more concise.

4. collect_tests: Simplified to a lambda using reduce. The functionality of recursively collecting tests from Python files remains the same, but the implementation is more compact.

5. execute_test: Refactored into a lambda that immediately evaluates the subprocess result. The test execution logic is unchanged, but the function is now a single expression.

6. create_test_summary: Converted to a lambda that constructs the summary dictionary. The logic for calculating passed/failed tests and creating the info list is preserved in a more compact form.

7. store_summary: Changed to a lambda that opens the file and writes JSON data in one expression. The file handling and JSON dumping functionality remains the same.

8. generate_test_coverage_report: Refactored into a lambda that executes both coverage commands in a tuple. The functionality is identical, but the implementation is more concise.

These changes make the code more compact and functional in style, while maintaining the same behavior and functionality. The refactoring focuses on reducing verbosity without altering the core logic or output of the program.

Closes #4182