### PR TITLE
Refactor NeuralArchitecture and TrainingEngine for TensorFlow conventions and code consistency

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,13 +23,13 @@ class ConfigManager:
 
 class NeuralArchitecture(tf.keras.Model):
     def __init__(self, vocab_size, embed_dim):
-        super(NeuralArchitecture, self).__init__()
+        super().__init__()
         self.embedding_layer = layers.Embedding(vocab_size, embed_dim)
         self.recurrent_layer = layers.LSTM(embed_dim, return_sequences=True, return_state=True)
         self.dense_layer1 = layers.Dense(embed_dim)
         self.dense_layer2 = layers.Dense(vocab_size)
 
-    def forward_pass(self, x):
+    def call(self, x):
         x = self.embedding_layer(x)
         x, _, _ = self.recurrent_layer(x)
         x = x[:, -1, :]
@@ -76,7 +76,7 @@ class TrainingEngine:
         for epoch in range(epochs):
             for input_ids, labels, neg_samples in data_loader:
                 with tf.GradientTape() as tape:
-                    loss = self.loss_fn(self.model.forward_pass(input_ids), labels, neg_samples)
+                    loss = self.loss_fn(self.model(input_ids), labels, neg_samples)
                 gradients = tape.gradient(loss, self.model.trainable_variables)
                 self.optimizer.apply_gradients(zip(gradients, self.model.trainable_variables))
             if self.check_early_stop(loss.numpy(), patience):
@@ -87,7 +87,7 @@ class TrainingEngine:
         self.model.eval()
         total_loss = 0
         for input_ids, labels, neg_samples in data_loader:
-            total_loss += self.loss_fn(self.model.forward_pass(input_ids), labels, neg_samples).numpy()
+            total_loss += self.loss_fn(self.model(input_ids), labels, neg_samples).numpy()
         print(f"Mean Evaluation Loss: {total_loss / len(data_loader):.4f}")
 
     def check_early_stop(self, current_loss, patience):


### PR DESCRIPTION
This pull request is linked to issue #4188.
    The main significant changes in the updated code are as follows:

1. **Method Renaming in NeuralArchitecture**: The `forward_pass` method in the `NeuralArchitecture` class has been renamed to `call`. This is a more conventional naming in TensorFlow models, as `call` is the standard method invoked when the model is called directly. This change aligns the code with TensorFlow's best practices.

2. **Superclass Initialization**: In the `NeuralArchitecture` class, the `super().__init__()` call has been simplified. The previous version explicitly passed the class name and `self`, which is redundant in Python 3. This change improves readability and adheres to modern Python conventions.

3. **Method Invocation in TrainingEngine**: The `forward_pass` method invocation in the `TrainingEngine` class has been replaced with direct model invocation (`self.model(input_ids)`). This change leverages the `call` method renaming and simplifies the code by removing the need for an explicit method call.

4. **Code Consistency**: The changes ensure consistency with TensorFlow's expected behavior, particularly in how models are called and initialized. This improves the maintainability and readability of the code, making it easier for contributors to understand and extend.

These changes are minimal but impactful, aligning the codebase with TensorFlow conventions and improving overall code quality without altering the core functionality.

Closes #4188