### PR TITLE
Add `send_notification` lambda function for system notifications after script completion

### DIFF
--- a/langchain_pipeline.py
+++ b/langchain_pipeline.py
@@ -81,6 +81,12 @@ create_log_backup = lambda: (
     logger.success("Backup completed!")
 ) if not (e := Exception()) else logger.error(f"Backup error: {e}")
 
+send_notification = lambda message: (
+    logger.info(f"Sending notification: {message}"),
+    run(["notify-send", "Script Notification", message], text=True, capture_output=True).stdout
+)
+
 if __name__ == "__main__":
     typer.run(execute_with_config)
     create_log_backup()
+    send_notification("Script execution completed!")


### PR DESCRIPTION
This pull request is linked to issue #4192.
    The main significant change in this code is the addition of a new `send_notification` lambda function, which sends a notification using the `notify-send` command. This function logs the notification message and executes the `notify-send` command to display a system notification with the provided message. The notification is triggered at the end of the script execution, specifically after the `create_log_backup` function is called. This enhancement improves user experience by providing immediate feedback upon script completion, especially useful in environments where users may not be actively monitoring the terminal. No other functional changes were made to the existing codebase.

Closes #4192