### PR TITLE
Add learning rate scheduler function for dynamic rate adjustment during training

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,5 +103,10 @@ def run_pipeline():
     trainer.run_evaluation(test_loader)
     store_model(model, os.path.join(config["results_dir"], "triplet_model.h5"))
 
+def add_learning_rate_scheduler(optimizer, initial_lr, decay_steps, decay_rate):
+    def lr_scheduler(step):
+        return initial_lr * (decay_rate ** (step // decay_steps))
+    return tf.keras.optimizers.schedules.LearningRateSchedule(lr_scheduler)
+
 if __name__ == "__main__":
     run_pipeline()


### PR DESCRIPTION
This pull request is linked to issue #4258.
    The main significant change in the updated code is the addition of a learning rate scheduler function, `add_learning_rate_scheduler`, which allows for dynamic adjustment of the learning rate during training. This function takes an optimizer, initial learning rate, decay steps, and decay rate as inputs and returns a learning rate schedule that decays the learning rate exponentially based on the number of steps. This change enhances the training process by potentially improving convergence and model performance, especially in scenarios where a fixed learning rate might lead to suboptimal results. The scheduler is not yet integrated into the training loop, but its addition provides flexibility for future implementation. No other functional changes were made to the existing codebase.

Closes #4258