### PR TITLE
Add `visualize_embedding_clusters` function and minor code adjustments for embedding analysis

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -136,6 +136,18 @@ def visualize_learning_rate_schedule(optimizer, scheduler, num_epochs):
     plt.legend()
     plt.show()
 
+def visualize_embedding_clusters(model, input_data, target_labels, n_clusters=5):
+    from sklearn.cluster import KMeans
+    embeddings = model(tf.convert_to_tensor(input_data, dtype=tf.int32)).numpy()
+    kmeans = KMeans(n_clusters=n_clusters)
+    cluster_labels = kmeans.fit_predict(embeddings)
+
+    plt.figure(figsize=(8, 8))
+    plt.scatter(embeddings[:, 0], embeddings[:, 1], c=cluster_labels, cmap='viridis')
+    plt.colorbar()
+    plt.title('Embedding Clusters')
+    plt.show()
+
 if __name__ == "__main__":
     synthetic_data, synthetic_labels = generate_synthetic_data(100)
     data_generator = TripletDataGenerator(synthetic_data, synthetic_labels, 5)
@@ -155,3 +167,4 @@ if __name__ == "__main__":
     visualize_similarity_matrix(embedding_model, synthetic_data)
     visualize_embedding_distribution(embedding_model, synthetic_data)
     visualize_learning_rate_schedule(model_optimizer, learning_rate_scheduler, 10)
+    visualize_embedding_clusters(embedding_model, synthetic_data, synthetic_labels)


### PR DESCRIPTION
This pull request is linked to issue #4284.
    The main significant changes in the updated code include the addition of a new function `visualize_embedding_clusters` and minor adjustments to the existing codebase. Below is a detailed explanation of the changes:

1. **New Function: `visualize_embedding_clusters`**  
   - This function has been added to visualize the clustering of embeddings using KMeans. It takes the model, input data, target labels, and an optional parameter `n_clusters` (default is 5).  
   - The function computes embeddings using the model, applies KMeans clustering, and then plots the clusters in a 2D scatter plot. This helps in understanding how well the embeddings are grouped in the latent space.  
   - The function uses `sklearn.cluster.KMeans` for clustering and `matplotlib` for visualization.

2. **Integration in Main Execution Block**  
   - The `visualize_embedding_clusters` function is called in the `__main__` block after training and evaluating the model. This allows users to see the clustering results alongside other visualizations like embedding space, similarity matrix, and embedding distribution.

3. **No Changes to Existing Functionality**  
   - The rest of the code, including the `WordEmbeddingNetwork` class, `TripletDataGenerator`, loss computation, training, evaluation, and other visualization functions, remains unchanged. The core functionality of the embedding network and its training pipeline is preserved.

These changes enhance the code by providing an additional tool for analyzing the quality of embeddings through clustering, which is particularly useful for understanding the structure of the learned embedding space.

Closes #4284