### PR TITLE
Refactor function and variable names for improved clarity and readability

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -8,36 +8,36 @@ from functools import reduce
 
 PYTHON_EXEC = "python3"
 
-def fetch_diff(repo_path, commit_id):
+def get_git_diff(repo_path, commit_id):
     os.chdir(repo_path)
     return subprocess.check_output(["git", "diff", commit_id, "--", "*.py"], text=True)
 
-def identify_changed_functions(diff_output):
+def extract_modified_functions(diff_output):
     return {
         func.split('(')[0].strip('+') for line in diff_output.split('\n') 
         if line.startswith('@@') and len(line.split()) > 3 and '(' in (func := line.split()[3])
     }
 
-def parse_script_for_tests(script_path):
+def scan_script_for_test_cases(script_path):
     return [
         {"file": str(script_path), "name": node.name, "calls": [n.func.id for n in node.body if isinstance(n, Call) and isinstance(n.func, Name)]}
         for node in parse(script_path.read_text(), filename=str(script_path)).body if isinstance(node, FunctionDef) and "test" in node.name
     ]
 
-def collect_all_tests(test_dir):
-    return reduce(lambda acc, file: acc + parse_script_for_tests(file), Path(test_dir).rglob("*.py"), [])
+def gather_all_test_cases(test_dir):
+    return reduce(lambda acc, file: acc + scan_script_for_test_cases(file), Path(test_dir).rglob("*.py"), [])
 
-def determine_impacted_tests(tests, changed_funcs):
+def find_affected_tests(test_cases, modified_funcs):
     return [
         {"file": test["file"], "name": test["name"], "called": call} 
-        for test in tests for call in test["calls"] if call in changed_funcs
+        for test in test_cases for call in test["calls"] if call in modified_funcs
     ]
 
-def execute_test(test_file, test_func):
+def run_test_case(test_file, test_func):
     result = subprocess.run([PYTHON_EXEC, "-m", "pytest", f"{test_file}::{test_func}"], capture_output=True, text=True)
     return result.returncode == 0
 
-def compile_test_results(test_data, results):
+def generate_test_summary(test_data, results):
     return {
         "total": len(test_data),
         "passed": sum(results),
@@ -45,11 +45,11 @@ def compile_test_results(test_data, results):
         "info": [{"name": test["name"], "file": test["file"], "result": "passed" if result else "failed"} for test, result in zip(test_data, results)]
     }
 
-def write_results_to_file(summary, output_file):
+def save_summary_to_file(summary, output_file):
     with open(output_file, "w") as file:
         json.dump(summary, file, indent=2)
 
-def produce_coverage_report(test_dir):
+def create_coverage_report(test_dir):
     subprocess.run([PYTHON_EXEC, "-m", "coverage", "run", "--source", test_dir, "-m", "pytest", test_dir])
     subprocess.run([PYTHON_EXEC, "-m", "coverage", "html", "-d", "coverage_report"])
 
@@ -62,29 +62,29 @@ def produce_coverage_report(test_dir):
 @click.option('--coverage', is_flag=True, help='Generate test coverage report')
 @click.option('--output', default="test_summary.json", help='Output file for test summary')
 def main(repo, commit, project, run, report, coverage, output):
-    diff = fetch_diff(repo, commit)
-    changed_funcs = identify_changed_functions(diff)
-    if not changed_funcs:
+    diff = get_git_diff(repo, commit)
+    modified_funcs = extract_modified_functions(diff)
+    if not modified_funcs:
         click.echo("No function changes detected.")
         return
     
-    tests = collect_all_tests(project)
-    impacted_tests = determine_impacted_tests(tests, changed_funcs)
-    click.echo(json.dumps(impacted_tests, indent=2))
+    test_cases = gather_all_test_cases(project)
+    affected_tests = find_affected_tests(test_cases, modified_funcs)
+    click.echo(json.dumps(affected_tests, indent=2))
     
     if run:
-        results = [execute_test(test['file'], test['name']) for test in impacted_tests]
-        for test, outcome in zip(impacted_tests, results):
+        results = [run_test_case(test['file'], test['name']) for test in affected_tests]
+        for test, outcome in zip(affected_tests, results):
             click.echo(f"Running test: {test['name']} in {test['file']}")
             click.echo(f"Test {test['name']} {'passed' if outcome else 'failed'}.")
         
         if report:
-            summary = compile_test_results(impacted_tests, results)
+            summary = generate_test_summary(affected_tests, results)
             click.echo(json.dumps(summary, indent=2))
-            write_results_to_file(summary, output)
+            save_summary_to_file(summary, output)
     
     if coverage:
-        produce_coverage_report(project)
+        create_coverage_report(project)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request is linked to issue #4334.
    The main changes in this code are primarily focused on renaming functions and variables to improve clarity and readability, without altering the core functionality. Here's a breakdown of the significant changes:

1. Function Renaming:
   - `fetch_diff` is renamed to `get_git_diff` to better reflect its purpose of retrieving Git diff output.
   - `identify_changed_functions` is renamed to `extract_modified_functions` for clarity.
   - `parse_script_for_tests` is renamed to `scan_script_for_test_cases` to better describe its role in scanning scripts for test cases.
   - `collect_all_tests` is renamed to `gather_all_test_cases` for consistency and clarity.
   - `determine_impacted_tests` is renamed to `find_affected_tests` to better convey its purpose of identifying affected tests.
   - `execute_test` is renamed to `run_test_case` for consistency with the naming convention.
   - `compile_test_results` is renamed to `generate_test_summary` to better describe its role in generating a summary of test results.
   - `write_results_to_file` is renamed to `save_summary_to_file` for clarity.
   - `produce_coverage_report` is renamed to `create_coverage_report` for consistency.

2. Variable Renaming:
   - `changed_funcs` is renamed to `modified_funcs` to better reflect the terminology used in the context of Git diffs.
   - `tests` is renamed to `test_cases` for clarity and consistency.
   - `impacted_tests` is renamed to `affected_tests` to better describe the tests affected by changes.

These changes are purely cosmetic and do not affect the logic or functionality of the code. The goal is to make the code more readable and maintainable by using more descriptive and consistent naming conventions.

Closes #4334