### PR TITLE
Transition from TensorFlow to PyTorch with updated model, loss, training, and data handling

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -1,20 +1,28 @@
-import tensorflow as tf
+import torch
+import torch.nn as nn
+import torch.optim as optim
 import numpy as np
 import matplotlib.pyplot as plt
 from sklearn.manifold import TSNE
 import random
-from tensorflow.keras import layers, models, optimizers
 from sklearn.cluster import KMeans
 
-class NeuralEmbedder(models.Sequential):
+class NeuralEmbedder(nn.Module):
     def __init__(self, vocab_size, embed_dim):
-        super().__init__([
-            layers.Embedding(vocab_size, embed_dim),
-            layers.GlobalAveragePooling1D(),
-            layers.Dense(embed_dim),
-            layers.BatchNormalization(),
-            layers.LayerNormalization()
-        ])
+        super(NeuralEmbedder, self).__init__()
+        self.embedding = nn.Embedding(vocab_size, embed_dim)
+        self.pooling = nn.AdaptiveAvgPool1d(1)
+        self.dense = nn.Linear(embed_dim, embed_dim)
+        self.batch_norm = nn.BatchNorm1d(embed_dim)
+        self.layer_norm = nn.LayerNorm(embed_dim)
+
+    def forward(self, x):
+        x = self.embedding(x)
+        x = self.pooling(x.transpose(1, 2)).squeeze(2)
+        x = self.dense(x)
+        x = self.batch_norm(x)
+        x = self.layer_norm(x)
+        return x
 
 class DataSampler:
     def __init__(self, data, labels, neg_samples):
@@ -32,29 +40,29 @@ class DataSampler:
         return anchor, pos, neg
 
 def compute_loss(anchor, pos, neg, margin=1.0):
-    pos_dist = tf.norm(anchor - pos, axis=1)
-    neg_dist = tf.reduce_min(tf.norm(tf.expand_dims(anchor, 1) - neg, axis=2), axis=1)
-    return tf.reduce_mean(tf.maximum(pos_dist - neg_dist + margin, 0.0))
+    pos_dist = torch.norm(anchor - pos, dim=1)
+    neg_dist = torch.min(torch.norm(anchor.unsqueeze(1) - neg, dim=2), dim=1)[0]
+    return torch.mean(torch.clamp(pos_dist - neg_dist + margin, min=0.0))
 
 def train_network(model, data_sampler, epochs, lr):
-    optimizer = optimizers.Adam(lr)
-    lr_scheduler = optimizers.schedules.ExponentialDecay(lr, decay_steps=30, decay_rate=0.1)
+    optimizer = optim.Adam(model.parameters(), lr=lr)
+    lr_scheduler = optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.1)
     loss_tracker = []
 
     for _ in range(epochs):
         batch_loss = []
         for a, p, n in data_sampler:
-            with tf.GradientTape() as tape:
-                loss = compute_loss(model(a), model(p), model(n)) + 0.01 * sum(tf.norm(param, ord=2) for param in model.trainable_variables)
-            grads = tape.gradient(loss, model.trainable_variables)
-            optimizer.apply_gradients(zip(grads, model.trainable_variables))
-            batch_loss.append(loss.numpy())
+            optimizer.zero_grad()
+            loss = compute_loss(model(a), model(p), model(n)) + 0.01 * sum(torch.norm(param, p=2) for param in model.parameters())
+            loss.backward()
+            optimizer.step()
+            batch_loss.append(loss.item())
         lr_scheduler.step()
         loss_tracker.append(np.mean(batch_loss))
     return loss_tracker
 
 def assess_model(model, data, labels, k=5):
-    embeddings = model(tf.convert_to_tensor(data, dtype=tf.int32)).numpy()
+    embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     distance_matrix = np.linalg.norm(embeddings[:, np.newaxis] - embeddings, axis=2)
     nearest_neighbors = np.argsort(distance_matrix, axis=1)[:, 1:k+1]
     correct = np.sum(labels[nearest_neighbors] == labels[:, np.newaxis], axis=1)
@@ -76,11 +84,11 @@ def assess_model(model, data, labels, k=5):
     plt.show()
 
 def persist_model(model, path):
-    model.save_weights(path)
+    torch.save(model.state_dict(), path)
 
 def restore_model(model_class, path, vocab_size, embed_dim):
     model = model_class(vocab_size, embed_dim)
-    model.load_weights(path)
+    model.load_state_dict(torch.load(path))
     return model
 
 def display_loss(loss_history):
@@ -96,7 +104,7 @@ def create_data(size):
     return np.random.randint(0, 100, (size, 10)), np.random.randint(0, 10, size)
 
 def show_embeddings(model, data, labels):
-    embeddings = model(tf.convert_to_tensor(data, dtype=tf.int32)).numpy()
+    embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     tsne = TSNE(n_components=2).fit_transform(embeddings)
 
     plt.figure(figsize=(8, 8))
@@ -106,7 +114,7 @@ def show_embeddings(model, data, labels):
     plt.show()
 
 def show_similarity(model, data):
-    embeddings = model(tf.convert_to_tensor(data, dtype=tf.int32)).numpy()
+    embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     cosine_similarity = np.dot(embeddings, embeddings.T) / (np.linalg.norm(embeddings, axis=1)[:, np.newaxis] * np.linalg.norm(embeddings, axis=1))
 
     plt.figure(figsize=(8, 8))
@@ -116,7 +124,7 @@ def show_similarity(model, data):
     plt.show()
 
 def show_distribution(model, data):
-    embeddings = model(tf.convert_to_tensor(data, dtype=tf.int32)).numpy()
+    embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     plt.figure(figsize=(8, 8))
     plt.hist(embeddings.flatten(), bins=50, color='blue', alpha=0.7)
     plt.title('Embedding Value Distribution')
@@ -127,7 +135,7 @@ def show_distribution(model, data):
 def show_lr_schedule(optimizer, scheduler, epochs):
     lr_history = []
     for _ in range(epochs):
-        lr_history.append(optimizer.learning_rate.numpy())
+        lr_history.append(optimizer.param_groups[0]['lr'])
         scheduler.step()
     plt.figure(figsize=(10, 5))
     plt.plot(lr_history, label='Learning Rate', color='red')
@@ -138,7 +146,7 @@ def show_lr_schedule(optimizer, scheduler, epochs):
     plt.show()
 
 def show_clusters(model, data, labels, n_clusters=5):
-    embeddings = model(tf.convert_to_tensor(data, dtype=tf.int32)).numpy()
+    embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     kmeans = KMeans(n_clusters=n_clusters)
     cluster_labels = kmeans.fit_predict(embeddings)
 
@@ -149,7 +157,7 @@ def show_clusters(model, data, labels, n_clusters=5):
     plt.show()
 
 def show_histogram(model, data):
-    embeddings = model(tf.convert_to_tensor(data, dtype=tf.int32)).numpy()
+    embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     plt.figure(figsize=(8, 8))
     plt.hist(embeddings.flatten(), bins=50, color='blue', alpha=0.7)
     plt.title('Embedding Value Histogram')
@@ -160,19 +168,15 @@ def show_histogram(model, data):
 if __name__ == "__main__":
     data, labels = create_data(100)
     sampler = DataSampler(data, labels, 5)
-    dataset = tf.data.Dataset.from_generator(lambda: sampler, output_signature=(
-        tf.TensorSpec(shape=(None,), dtype=tf.int32),
-        tf.TensorSpec(shape=(None,), dtype=tf.int32),
-        tf.TensorSpec(shape=(None,), dtype=tf.int32)
-    )).batch(32).shuffle(1000)
+    dataset = torch.utils.data.DataLoader(sampler, batch_size=32, shuffle=True)
     model = NeuralEmbedder(101, 10)
-    optimizer = optimizers.Adam(1e-4)
-    lr_scheduler = optimizers.schedules.ExponentialDecay(1e-4, decay_steps=30, decay_rate=0.1)
+    optimizer = optim.Adam(model.parameters(), lr=1e-4)
+    lr_scheduler = optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.1)
     loss_history = train_network(model, dataset, 10, 1e-4)
-    persist_model(model, "embedding_model.h5")
+    persist_model(model, "embedding_model.pth")
     display_loss(loss_history)
     assess_model(model, data, labels)
-    show_embeddings(restore_model(NeuralEmbedder, "embedding_model.h5", 101, 10), *create_data(100))
+    show_embeddings(restore_model(NeuralEmbedder, "embedding_model.pth", 101, 10), *create_data(100))
     show_similarity(model, data)
     show_distribution(model, data)
     show_lr_schedule(optimizer, lr_scheduler, 10)


### PR DESCRIPTION
This pull request is linked to issue #4378.
    The main significant changes in the updated code involve transitioning from TensorFlow to PyTorch, which includes several key modifications:

1. Model Definition: The `NeuralEmbedder` class is now defined using PyTorch's `nn.Module` instead of TensorFlow's `models.Sequential`. The layers are defined using PyTorch equivalents: `nn.Embedding`, `nn.AdaptiveAvgPool1d`, `nn.Linear`, `nn.BatchNorm1d`, and `nn.LayerNorm`. The forward pass is explicitly defined in the `forward` method.

2. Loss Computation: The `compute_loss` function now uses PyTorch operations (`torch.norm`, `torch.clamp`) instead of TensorFlow operations (`tf.norm`, `tf.maximum`). The logic remains the same, but the syntax is adapted to PyTorch.

3. Training Loop: The `train_network` function is updated to use PyTorch's optimizer (`optim.Adam`) and learning rate scheduler (`optim.lr_scheduler.ExponentialLR`). The gradient computation and update steps are handled using `optimizer.zero_grad()`, `loss.backward()`, and `optimizer.step()`.

4. Data Handling: The `DataSampler` class remains largely unchanged, but the dataset is now wrapped in a PyTorch `DataLoader` instead of TensorFlow's `Dataset`. This allows for batching and shuffling using PyTorch's utilities.

5. Model Persistence: Model saving and loading are updated to use PyTorch's `torch.save` and `torch.load` functions, which save and load the model's state dictionary (`state_dict`).

6. Visualization and Evaluation: Functions like `assess_model`, `show_embeddings`, `show_similarity`, `show_distribution`, `show_lr_schedule`, `show_clusters`, and `show_histogram` are adapted to use PyTorch tensors and operations. The core logic remains the same, but the syntax is updated to match PyTorch.

These changes ensure that the codebase is fully compatible with PyTorch, leveraging its dynamic computation graph and extensive library support while maintaining the original functionality.

Closes #4378