### PR TITLE
Remove TODO comment in `main` function, no functional changes or improvements made

### DIFF
--- a/find_calls_in_tests.py
+++ b/find_calls_in_tests.py
@@ -68,7 +68,7 @@ def main(repo, commit, project, run, report, coverage, output):
         click.echo("No function changes detected.")
         return
     
-    test_cases = gather_all_test_cases(project)  # TODO: Function name needs correction, should be `gather_all_test_cases`
+    test_cases = gather_all_test_cases(project)
     affected_tests = find_affected_tests(test_cases, modified_funcs)
     click.echo(json.dumps(affected_tests, indent=2))
     


### PR DESCRIPTION
This pull request is linked to issue #4416.
    The main significant changes in this code are minimal, as the updated code is nearly identical to the original. The only notable change is the removal of a TODO comment in the `main` function. The original code had a comment indicating that the function name `gather_all_test_cases` needed correction, but this comment has been removed in the updated version. This suggests that the function name was deemed appropriate, and no further action was required. 

No functional changes, bug fixes, or performance improvements were made. The logic for extracting modified functions, scanning for test cases, running tests, generating summaries, and creating coverage reports remains unchanged. The code continues to use the same libraries (`os`, `subprocess`, `json`, `click`, `ast`, `pathlib`, and `functools`) and follows the same structure for handling Git diffs, identifying affected tests, and executing them based on the provided command-line options. 

The removal of the TODO comment is the only change, indicating that the code is now considered complete in terms of naming conventions and functionality.

Closes #4416