### PR TITLE
Refactor code with improved naming conventions for classes, functions, and variables

### DIFF
--- a/our_trainers.py
+++ b/our_trainers.py
@@ -7,24 +7,24 @@ from sklearn.manifold import TSNE
 import random
 from sklearn.cluster import KMeans
 
-class NeuralEmbedder(nn.Module):
+class WordVectorGenerator(nn.Module):
     def __init__(self, vocab_size, embed_dim):
-        super(NeuralEmbedder, self).__init__()
-        self.embedding = nn.Embedding(vocab_size, embed_dim)
-        self.pooling = nn.AdaptiveAvgPool1d(1)
-        self.dense = nn.Linear(embed_dim, embed_dim)
-        self.batch_norm = nn.BatchNorm1d(embed_dim)
-        self.layer_norm = nn.LayerNorm(embed_dim)
+        super(WordVectorGenerator, self).__init__()
+        self.vector_layer = nn.Embedding(vocab_size, embed_dim)
+        self.pooling_layer = nn.AdaptiveAvgPool1d(1)
+        self.linear_layer = nn.Linear(embed_dim, embed_dim)
+        self.batch_norm_layer = nn.BatchNorm1d(embed_dim)
+        self.layer_norm_layer = nn.LayerNorm(embed_dim)
 
     def forward(self, x):
-        x = self.embedding(x)
-        x = self.pooling(x.transpose(1, 2)).squeeze(2)
-        x = self.dense(x)
-        x = self.batch_norm(x)
-        x = self.layer_norm(x)
+        x = self.vector_layer(x)
+        x = self.pooling_layer(x.transpose(1, 2)).squeeze(2)
+        x = self.linear_layer(x)
+        x = self.batch_norm_layer(x)
+        x = self.layer_norm_layer(x)
         return x
 
-class DataSampler:
+class TripletSampler:
     def __init__(self, data, labels, neg_samples):
         self.data = data
         self.labels = labels
@@ -39,29 +39,29 @@ class DataSampler:
         neg = random.sample(self.data[self.labels != self.labels[idx]].tolist(), self.neg_samples)
         return anchor, pos, neg
 
-def compute_loss(anchor, pos, neg, margin=1.0):
+def calculate_triplet_loss(anchor, pos, neg, margin=1.0):
     pos_dist = torch.norm(anchor - pos, dim=1)
     neg_dist = torch.min(torch.norm(anchor.unsqueeze(1) - neg, dim=2), dim=1)[0]
     return torch.mean(torch.clamp(pos_dist - neg_dist + margin, min=0.0))
 
-def train_network(model, data_sampler, epochs, lr):
+def train_model(model, data_sampler, epochs, lr):
     optimizer = optim.Adam(model.parameters(), lr=lr)
     lr_scheduler = optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.1)
-    loss_tracker = []
+    loss_history = []
 
     for _ in range(epochs):
         batch_loss = []
         for a, p, n in data_sampler:
             optimizer.zero_grad()
-            loss = compute_loss(model(a), model(p), model(n)) + 0.01 * sum(torch.norm(param, p=2) for param in model.parameters())
+            loss = calculate_triplet_loss(model(a), model(p), model(n)) + 0.01 * sum(torch.norm(param, p=2) for param in model.parameters())
             loss.backward()
             optimizer.step()
             batch_loss.append(loss.item())
         lr_scheduler.step()
-        loss_tracker.append(np.mean(batch_loss))
-    return loss_tracker
+        loss_history.append(np.mean(batch_loss))
+    return loss_history
 
-def assess_model(model, data, labels, k=5):
+def evaluate_model(model, data, labels, k=5):
     embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     distance_matrix = np.linalg.norm(embeddings[:, np.newaxis] - embeddings, axis=2)
     nearest_neighbors = np.argsort(distance_matrix, axis=1)[:, 1:k+1]
@@ -83,15 +83,15 @@ def assess_model(model, data, labels, k=5):
     plt.colorbar()
     plt.show()
 
-def persist_model(model, path):
+def save_model(model, path):
     torch.save(model.state_dict(), path)
 
-def restore_model(model_class, path, vocab_size, embed_dim):
+def load_model(model_class, path, vocab_size, embed_dim):
     model = model_class(vocab_size, embed_dim)
     model.load_state_dict(torch.load(path))
     return model
 
-def display_loss(loss_history):
+def plot_loss(loss_history):
     plt.figure(figsize=(10, 5))
     plt.plot(loss_history, label='Loss', color='blue')
     plt.title('Training Loss Over Epochs')
@@ -100,10 +100,10 @@ def display_loss(loss_history):
     plt.legend()
     plt.show()
 
-def create_data(size):
+def generate_data(size):
     return np.random.randint(0, 100, (size, 10)), np.random.randint(0, 10, size)
 
-def show_embeddings(model, data, labels):
+def visualize_embeddings(model, data, labels):
     embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     tsne = TSNE(n_components=2).fit_transform(embeddings)
 
@@ -113,7 +113,7 @@ def show_embeddings(model, data, labels):
     plt.gcf().canvas.mpl_connect('button_press_event', lambda event: print(f"Clicked on point with label: {labels[np.argmin(np.linalg.norm(tsne - np.array([event.xdata, event.ydata]), axis=1))]}") if event.inaxes is not None else None)
     plt.show()
 
-def show_similarity(model, data):
+def visualize_similarity(model, data):
     embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     cosine_similarity = np.dot(embeddings, embeddings.T) / (np.linalg.norm(embeddings, axis=1)[:, np.newaxis] * np.linalg.norm(embeddings, axis=1))
 
@@ -123,7 +123,7 @@ def show_similarity(model, data):
     plt.title('Cosine Similarity Matrix')
     plt.show()
 
-def show_distribution(model, data):
+def visualize_distribution(model, data):
     embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     plt.figure(figsize=(8, 8))
     plt.hist(embeddings.flatten(), bins=50, color='blue', alpha=0.7)
@@ -132,7 +132,7 @@ def show_distribution(model, data):
     plt.ylabel('Frequency')
     plt.show()
 
-def show_lr_schedule(optimizer, scheduler, epochs):
+def visualize_lr_schedule(optimizer, scheduler, epochs):
     lr_history = []
     for _ in range(epochs):
         lr_history.append(optimizer.param_groups[0]['lr'])
@@ -145,7 +145,7 @@ def show_lr_schedule(optimizer, scheduler, epochs):
     plt.legend()
     plt.show()
 
-def show_clusters(model, data, labels, n_clusters=5):
+def visualize_clusters(model, data, labels, n_clusters=5):
     embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     kmeans = KMeans(n_clusters=n_clusters)
     cluster_labels = kmeans.fit_predict(embeddings)
@@ -156,7 +156,7 @@ def show_clusters(model, data, labels, n_clusters=5):
     plt.title('Embedding Clusters')
     plt.show()
 
-def show_histogram(model, data):
+def visualize_histogram(model, data):
     embeddings = model(torch.tensor(data, dtype=torch.int32)).detach().numpy()
     plt.figure(figsize=(8, 8))
     plt.hist(embeddings.flatten(), bins=50, color='blue', alpha=0.7)
@@ -166,19 +166,19 @@ def show_histogram(model, data):
     plt.show()
 
 if __name__ == "__main__":
-    data, labels = create_data(100)
-    sampler = DataSampler(data, labels, 5)
+    data, labels = generate_data(100)
+    sampler = TripletSampler(data, labels, 5)
     dataset = torch.utils.data.DataLoader(sampler, batch_size=32, shuffle=True)
-    model = NeuralEmbedder(101, 10)
+    model = WordVectorGenerator(101, 10)
     optimizer = optim.Adam(model.parameters(), lr=1e-4)
     lr_scheduler = optim.lr_scheduler.ExponentialLR(optimizer, gamma=0.1)
-    loss_history = train_network(model, dataset, 10, 1e-4)
-    persist_model(model, "embedding_model.pth")
-    display_loss(loss_history)
-    assess_model(model, data, labels)
-    show_embeddings(restore_model(NeuralEmbedder, "embedding_model.pth", 101, 10), *create_data(100))
-    show_similarity(model, data)
-    show_distribution(model, data)
-    show_lr_schedule(optimizer, lr_scheduler, 10)
-    show_clusters(model, data, labels)
-    show_histogram(model, data)
+    loss_history = train_model(model, dataset, 10, 1e-4)
+    save_model(model, "embedding_model.pth")
+    plot_loss(loss_history)
+    evaluate_model(model, data, labels)
+    visualize_embeddings(load_model(WordVectorGenerator, "embedding_model.pth", 101, 10), *generate_data(100))
+    visualize_similarity(model, data)
+    visualize_distribution(model, data)
+    visualize_lr_schedule(optimizer, lr_scheduler, 10)
+    visualize_clusters(model, data, labels)
+    visualize_histogram(model, data)


### PR DESCRIPTION
This pull request is linked to issue #4426.
    The main significant changes in the updated code are primarily focused on renaming classes, functions, and variables for improved clarity and consistency. Here's a breakdown of the key changes:

1. Class Renaming:
   - `NeuralEmbedder` is renamed to `WordVectorGenerator` to better reflect its purpose of generating word vectors.
   - `DataSampler` is renamed to `TripletSampler` to emphasize its role in sampling triplets for triplet loss.

2. Function Renaming:
   - `compute_loss` is renamed to `calculate_triplet_loss` to clarify that it computes the triplet loss.
   - `train_network` is renamed to `train_model` for simplicity and consistency.
   - `assess_model` is renamed to `evaluate_model` to align with common terminology.
   - `persist_model` and `restore_model` are renamed to `save_model` and `load_model` respectively for clarity.
   - `display_loss` is renamed to `plot_loss` to better describe its functionality.
   - `create_data` is renamed to `generate_data` for consistency.
   - `show_embeddings`, `show_similarity`, `show_distribution`, `show_lr_schedule`, `show_clusters`, and `show_histogram` are renamed to `visualize_embeddings`, `visualize_similarity`, `visualize_distribution`, `visualize_lr_schedule`, `visualize_clusters`, and `visualize_histogram` respectively to emphasize their visualization purpose.

3. Variable Renaming:
   - `embedding`, `pooling`, `dense`, `batch_norm`, and `layer_norm` in `NeuralEmbedder` are renamed to `vector_layer`, `pooling_layer`, `linear_layer`, `batch_norm_layer`, and `layer_norm_layer` respectively for better readability.

These changes enhance code readability and maintainability by using more descriptive and consistent naming conventions. The functionality remains unchanged, ensuring that the code continues to perform as expected.

Closes #4426