### PR TITLE
Fix syntax error in `evaluate_network`, rename `epochs` to `num_epochs`, improve code readability

### DIFF
--- a/out_dataset.py
+++ b/out_dataset.py
@@ -83,7 +83,7 @@ def evaluate_network(model, data_loader):
         for batch in data_loader:
             anchor, positive, negative = model(batch['anchor']), model(batch['positive']), model(batch['negative'])
             total_loss += compute_triplet_loss(anchor, positive, negative).item()
-            correct += torch.sum((torch.sum(anchor * positive, dim=1) > torch.sum(anchor * negative, dim=1)).item()
+            correct += torch.sum((torch.sum(anchor * positive, dim=1) > torch.sum(anchor * negative, dim=1))).item()
     return total_loss / len(data_loader), correct / len(data_loader)
 
 def plot_training_progress(history):
@@ -143,7 +143,7 @@ def execute_pipeline():
     train_loader = DataLoader(train_data.tolist(), batch_size=32, shuffle=True)
     valid_loader = DataLoader(valid_data.tolist(), batch_size=32)
     model = EmbeddingNetwork(vocab_size=len(train_loader.dataset[0]['anchor']) + 1, embedding_dim=128)
-    history = train_network(model, train_loader, valid_loader, epochs=5)
+    history = train_network(model, train_loader, valid_loader, num_epochs=5)
     plot_training_progress(history)
     save_model_weights(model, 'model.pth')
     visualize_embeddings(model, valid_loader)


### PR DESCRIPTION
This pull request is linked to issue #4436.
    The main significant changes in the updated code are as follows:

1. **Bug Fix in `evaluate_network` Function**: The `evaluate_network` function had a syntax error in the line where the `correct` variable was being updated. The parentheses were mismatched, causing a syntax error. This has been fixed by properly closing the parentheses for the `torch.sum` operation.

2. **Parameter Naming Consistency**: In the `train_network` function, the parameter `epochs` was renamed to `num_epochs` to maintain consistency with the function signature and improve readability. This change ensures that the parameter name aligns with the function's purpose and avoids confusion.

3. **Code Readability and Maintainability**: The overall structure and logic of the code remain unchanged, but the fixes and renaming improve the code's readability and maintainability. These changes ensure that the code is easier to understand and less prone to errors during future modifications.

These changes are minimal but crucial for the correct functioning of the code, especially in a production environment where such small errors can lead to significant issues. The updates ensure that the code runs smoothly and is easier to maintain.

Closes #4436